### PR TITLE
add applications.active boolean flag

### DIFF
--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -3,9 +3,14 @@
   width: 100%;
 }
 
-.wrapper.actions form {
+.wrapper.actions form, .wrapper.actions .action {
   float: left;
   display: inline;
+}
+
+.wrapper.actions .action a {
+  margin-top: 2.5rem;
+  margin-bottom: 1.5em;
 }
 
 .alert button.close {

--- a/app/controllers/users/applications_controller.rb
+++ b/app/controllers/users/applications_controller.rb
@@ -53,7 +53,7 @@ module Users
     end
 
     def application_params
-      params.require(:application).permit(:name, :description, :metadata_url, :acs_url, :assertion_consumer_logout_service_url, :saml_client_cert, :block_encryption)
+      params.require(:application).permit(:name, :description, :metadata_url, :acs_url, :assertion_consumer_logout_service_url, :saml_client_cert, :block_encryption, :active)
     end
 
     helper_method :application

--- a/app/views/users/applications/_form.html.slim
+++ b/app/views/users/applications/_form.html.slim
@@ -6,3 +6,4 @@
 = form.input :assertion_consumer_logout_service_url, label: 'Assertion Consumer Logout Service URL'
 = form.input :saml_client_cert, label: 'SAML Client Cert (PEM encoded)'
 = form.input :block_encryption, as: :radio_buttons, label: 'Block Encryption'
+= form.input :active, as: :radio_buttons

--- a/app/views/users/applications/_form.html.slim
+++ b/app/views/users/applications/_form.html.slim
@@ -2,7 +2,7 @@
 = form.input :name
 = form.input :description
 = form.input :metadata_url, label: 'Metadata URL'
-= form.input :acs_url, label: 'ACS URL'
+= form.input :acs_url, label: 'Assertion Consumer Service URL'
 = form.input :assertion_consumer_logout_service_url, label: 'Assertion Consumer Logout Service URL'
 = form.input :saml_client_cert, label: 'SAML Client Cert (PEM encoded)'
 = form.input :block_encryption, as: :radio_buttons, label: 'Block Encryption'

--- a/app/views/users/applications/edit.html.slim
+++ b/app/views/users/applications/edit.html.slim
@@ -2,5 +2,8 @@ h1 = t('dashboard.headings.applications.edit', name: application.name)
 
 = simple_form_for(application, html: { autocomplete: 'off', role: 'form' }, url: users_application_path(application)) do |form|
   == render 'form', { form: form }
-  = link_to t('dashboard.forms.buttons.cancel'), users_application_url(application), class: 'usa-button-outline button secondary', role: :button 
-  = form.button :submit, 'Update'
+  .wrapper.actions
+    .action
+      = form.button :submit, 'Update'
+    .action
+      = link_to t('dashboard.forms.buttons.cancel'), users_application_url(application), class: 'usa-button usa-button-outline use-button-secondary', role: :button

--- a/app/views/users/applications/index.html.slim
+++ b/app/views/users/applications/index.html.slim
@@ -5,8 +5,9 @@ h1
   = button_to t('dashboard.forms.buttons.create_application'), new_users_application_url, 
     class: 'usa-button-primary', method: :get
 
-ul
+table
   - current_user.applications.each do |app|
-    li
-      = link_to(app.name, users_application_path(app), { title: app.issuer })
-
+    tr
+      td = link_to(app.name, users_application_path(app))
+      td = app.issuer
+      td = app.active? ? 'Active' : 'Inactive'

--- a/app/views/users/applications/show.html.slim
+++ b/app/views/users/applications/show.html.slim
@@ -31,3 +31,6 @@ table
   tr
     th Block Encryption
     td.block_encryption = application.block_encryption
+  tr
+    th Active?
+    td.active_flag = (application.active? ? 'Yes' : 'No')

--- a/app/views/users/applications/show.html.slim
+++ b/app/views/users/applications/show.html.slim
@@ -20,7 +20,7 @@ table
     th Metadata URL
     td.metadata_url = application.metadata_url
   tr
-    th ACS URL
+    th Assertion Consumer Service URL
     td.acs_url = application.acs_url
   tr
     th Assertion Consumer Logout Service URL

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,23 +11,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160509215026) do
+ActiveRecord::Schema.define(version: 20160516150051) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "applications", force: :cascade do |t|
-    t.integer  "user_id",                                           null: false
-    t.uuid     "issuer",                                            null: false
+    t.integer  "user_id",                                               null: false
+    t.uuid     "issuer",                                                null: false
     t.string   "name"
     t.text     "description"
     t.text     "metadata_url"
     t.text     "acs_url"
     t.text     "assertion_consumer_logout_service_url"
     t.text     "saml_client_cert"
-    t.integer  "block_encryption",                      default: 1, null: false
+    t.integer  "block_encryption",                      default: 1,     null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean  "active",                                default: false, null: false
   end
 
   add_index "applications", ["issuer"], name: "index_applications_on_issuer", unique: true, using: :btree


### PR DESCRIPTION
Rationale:
Service providers may want to register applications, and then toggle them on/off.