### PR TITLE
fix email subject for application create/approve notifications

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ end
 
 group :test do
   gem 'codeclimate-test-reporter', require: nil
+  gem 'climate_control'
   gem 'database_cleaner'
   gem 'formulaic'
   gem 'launchy'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,8 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    climate_control (0.0.3)
+      activesupport (>= 3.0)
     cliver (0.3.2)
     codeclimate-test-reporter (0.5.1)
       simplecov (>= 0.7.1, < 1.0.0)
@@ -381,6 +383,7 @@ DEPENDENCIES
   bourbon (= 5.0.0.beta.5)
   bullet
   bundler-audit (>= 0.5.0)
+  climate_control
   codeclimate-test-reporter
   coffee-rails (~> 4.1.0)
   database_cleaner
@@ -435,6 +438,9 @@ DEPENDENCIES
   us_web_design_standards!
   web-console
   webmock
+
+RUBY VERSION
+   ruby 2.3.0p0
 
 BUNDLED WITH
    1.12.1

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -14,7 +14,7 @@ class UserMailer < ApplicationMailer
     @application = app
     mail(
       to: admin_email_address,
-      subject: I18n.t('dashboard.mailer.new_application', id: app.issuer)
+      subject: I18n.t('dashboard.mailer.new_application.subject', id: app.issuer)
     )
   end
 
@@ -22,7 +22,7 @@ class UserMailer < ApplicationMailer
     @application = app
     mail(
       to: app.user.email,
-      subject: I18n.t('dashboard.mailer.new_application', id: app.issuer)
+      subject: I18n.t('dashboard.mailer.new_application.subject', id: app.issuer)
     )
   end
 
@@ -30,7 +30,7 @@ class UserMailer < ApplicationMailer
     @application = app
     mail(
       to: admin_email_address,
-      subject: I18n.t('dashboard.mailer.approved_application', id: app.issuer)
+      subject: I18n.t('dashboard.mailer.approved_application.subject', id: app.issuer)
     )
   end
 
@@ -38,7 +38,7 @@ class UserMailer < ApplicationMailer
     @application = app
     mail(
       to: app.user.email,
-      subject: I18n.t('dashboard.mailer.approved_application', id: app.issuer)
+      subject: I18n.t('dashboard.mailer.approved_application.subject', id: app.issuer)
     )
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+describe UserMailer, type: :mailer do
+  let(:app) { create(:application) }
+
+  describe 'user_new_application' do
+    let(:mail) { UserMailer.user_new_application(app) }
+
+    it 'sends to app owner' do
+      expect(mail.to).to eq [app.user.email]
+    end
+
+    it 'renders the subject' do
+      expect(mail.subject).to eq t('dashboard.mailer.new_application.subject', id: app.issuer)
+    end
+  end
+
+  describe 'admin_new_application' do
+    let(:mail) { UserMailer.admin_new_application(app) }
+
+    it 'sends to ADMIN_EMAIL' do
+      ClimateControl.modify ADMIN_EMAIL: 'identity-admin@example.com' do
+        expect(mail.to).to eq ['identity-admin@example.com']
+      end
+    end
+
+    it 'renders the subject' do
+      expect(mail.subject).to eq t('dashboard.mailer.new_application.subject', id: app.issuer)
+    end
+  end
+
+  describe 'user_approved_application' do
+    let(:mail) { UserMailer.user_approved_application(app) }
+
+    it 'sends to app owner' do
+      expect(mail.to).to eq [app.user.email]
+    end
+
+    it 'renders the subject' do
+      expect(mail.subject).to eq t('dashboard.mailer.approved_application.subject', id: app.issuer)
+    end
+  end
+
+  describe 'admin_approved_application' do
+    let(:mail) { UserMailer.admin_approved_application(app) }
+
+    it 'sends to ADMIN_EMAIL' do
+      ClimateControl.modify ADMIN_EMAIL: 'identity-admin@example.com' do
+        expect(mail.to).to eq ['identity-admin@example.com']
+      end
+    end
+
+    it 'renders the subject' do
+      expect(mail.subject).to eq t('dashboard.mailer.approved_application.subject', id: app.issuer)
+    end
+  end
+end

--- a/spec/requests/applications_spec.rb
+++ b/spec/requests/applications_spec.rb
@@ -22,15 +22,53 @@ describe 'Users::Applications' do
     end
 
     it 'allows admin to approve' do
-      app = create(:application)
-      admin_user = create(:user, admin: true)
-      login_as(admin_user)
+      ClimateControl.modify ADMIN_EMAIL: 'identity-admin@example.com' do
+        app = create(:application)
+        admin_user = create(:user, admin: true)
+        deliveries.clear
+        login_as(admin_user)
 
-      put users_application_path(app), application: { approved: 'true' }
+        mailer = instance_double(ActionMailer::MessageDelivery)
+        allow(UserMailer).to receive(:admin_approved_application).with(anything).and_return(mailer)
+        allow(UserMailer).to receive(:user_approved_application).with(anything).and_return(mailer)
+        allow(mailer).to receive(:deliver_later)
 
-      expect(response.status).to eq(302) # redirect on success
-      app.reload
-      expect(app.approved?).to eq(true)
+        put users_application_path(app), application: { approved: 'true' }
+
+        expect(response.status).to eq(302) # redirect on success
+        app.reload
+        expect(app.approved?).to eq(true)
+
+        expect(UserMailer).to have_received(:admin_approved_application).with(app)
+        expect(UserMailer).to have_received(:user_approved_application).with(app)
+        expect(mailer).to have_received(:deliver_later).twice
+      end
+    end
+  end
+
+  describe 'notifications' do
+    it 'sends email to admin requesting approval' do
+      ClimateControl.modify ADMIN_EMAIL: 'identity-admin@example.com' do
+        user = create(:user)
+        deliveries.clear
+        login_as(user)
+
+        mailer = instance_double(ActionMailer::MessageDelivery)
+        allow(UserMailer).to receive(:admin_new_application).with(anything).and_return(mailer)
+        allow(UserMailer).to receive(:user_new_application).with(anything).and_return(mailer)
+        allow(mailer).to receive(:deliver_later)
+
+        post users_applications_path, application: { name: 'test' }
+
+        app = Application.last
+
+        expect(UserMailer).to have_received(:admin_new_application).with(app)
+        expect(UserMailer).to have_received(:user_new_application).with(app)
+        expect(mailer).to have_received(:deliver_later).twice
+
+        expect(response.status).to eq(302)
+        expect(app.approved).to eq(false)
+      end
     end
   end
 


### PR DESCRIPTION
Fixes bug in email subject where I18n key was wrong, and adds tests to verify.