### PR TITLE
Fix production secrets

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -14,3 +14,5 @@ staging:
 
 production:
   secret_key_base: <%= ENV['SECRET_KEY_BASE'] %>
+  http_auth_username: <%= ENV["SP_NAME"] %>
+  http_auth_password: <%= ENV["SP_PASS"] %>


### PR DESCRIPTION
**Why**:
I thought default was shared across all environments, it is shared
across all enviromments _except_ production, so this brings back
the secrets I removed from prod accidentally in 4d7a70f9498367
