### PR TITLE
Add missing require

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -28,6 +28,7 @@ namespace :deploy do
   desc 'Write deploy information to deploy.json'
   task :deploy_json do
     on roles(:web), in: :parallel do
+      require 'json'
       require 'stringio'
 
       within current_path do


### PR DESCRIPTION
(it's a bummer this worked fine in 18F/identity-idp and didn't need this require. I tested this one manually)

**Why**:
Because I got this error when I deployed:

```
NoMethodError: undefined method `to_json' for #<Hash:0x007fd504082470>
Did you mean?  to_s
```