### PR TITLE
Rearrange order of environments on deploy dashboard

### DIFF
--- a/app/services/deploy_status_checker.rb
+++ b/app/services/deploy_status_checker.rb
@@ -15,15 +15,15 @@ class DeployStatusChecker
     Deploy.new('identity-sp-sinatra', 'demo', 'sp-sinatra.demo.login.gov'),
     Deploy.new('identity-dashboard', 'demo', 'dashboard.demo.login.gov'),
 
-    Deploy.new('identity-idp', 'dev', 'idp.dev.login.gov'),
-    Deploy.new('identity-sp-rails', 'dev', 'sp.dev.login.gov'),
-    Deploy.new('identity-sp-sinatra', 'dev', 'sp-sinatra.dev.login.gov'),
-    Deploy.new('identity-dashboard', 'dev', 'dashboard.dev.login.gov'),
-
     Deploy.new('identity-idp', 'qa', 'idp.qa.login.gov'),
     Deploy.new('identity-sp-rails', 'qa', 'sp.qa.login.gov'),
     Deploy.new('identity-sp-sinatra', 'qa', 'sp-sinatra.qa.login.gov'),
-    Deploy.new('identity-dashboard', 'qa', 'dashboard.qa.login.gov')
+    Deploy.new('identity-dashboard', 'qa', 'dashboard.qa.login.gov'),
+
+    Deploy.new('identity-idp', 'dev', 'idp.dev.login.gov'),
+    Deploy.new('identity-sp-rails', 'dev', 'sp.dev.login.gov'),
+    Deploy.new('identity-sp-sinatra', 'dev', 'sp-sinatra.dev.login.gov'),
+    Deploy.new('identity-dashboard', 'dev', 'dashboard.dev.login.gov')
   ].freeze
 
   Status = Struct.new(:app, :env, :host, :sha, :branch, :user, :timestamp, :error) do


### PR DESCRIPTION
**Why**:
Matches our deploy flow: dev -> qa -> demo

