### PR TITLE
change secret_key_base to dashboard_secret_key_base

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -13,6 +13,6 @@ staging:
   <<: *default
 
 production:
-  secret_key_base: <%= ENV['SECRET_KEY_BASE'] %>
+  secret_key_base: <%= ENV['DASHBOARD_SECRET_KEY_BASE'] %>
   http_auth_username: <%= ENV["SP_NAME"] %>
   http_auth_password: <%= ENV["SP_PASS"] %>


### PR DESCRIPTION
**why**
otherwise, it overwrites secret key base for sp-rails or sp-sinatra because they shared the same env var name. 