### PR TITLE
Adds 2 second open_timeout to HTTP request

### DIFF
--- a/app/services/deploy_status_checker.rb
+++ b/app/services/deploy_status_checker.rb
@@ -76,8 +76,10 @@ class DeployStatusChecker
   def load_status(deploy)
     uri = URI.join(deploy.host, '/api/deploy.json')
 
-    Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
-      request = Net::HTTP::Get.new(uri)
+    Net::HTTP.start(uri.host, uri.port,
+                    use_ssl: uri.scheme == 'https',
+                    open_timeout: 2) do |http|
+      request = Net::HTTP::Get.new(uri.request_uri)
       basic_auth(request)
       http.request(request)
     end


### PR DESCRIPTION
### Why
When checking the deploy status on our applications, we must
open an HTTP connection to the API; when the service is completely
down, the Rack::Timeout is reached before the individual API calls
time out.

### How
Add an open_timeout to the HTTP request to each individual API.