### PR TITLE
Add /api/service_providers endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ before_script:
 rvm:
 - 2.3.3
 cache: bundler
+notifications:
+  email: false
 script:
   - make test
   - bundle exec codeclimate-test-reporter

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 ruby '2.3.3'
 
 gem 'actionmailer-text'
+gem 'active_model_serializers'
 gem 'bourbon', '5.0.0.beta.5'
 gem 'coffee-rails', '~> 4.1.0'
 gem 'delayed_job_active_record'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,11 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    active_model_serializers (0.10.4)
+      actionpack (>= 4.1, < 6)
+      activemodel (>= 4.1, < 6)
+      case_transform (>= 0.2)
+      jsonapi (= 0.1.1.beta6)
     activejob (4.2.7.1)
       activesupport (= 4.2.7.1)
       globalid (>= 0.3.0)
@@ -91,6 +96,8 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    case_transform (0.2)
+      activesupport
     climate_control (0.0.3)
       activesupport (>= 3.0)
     cliver (0.3.2)
@@ -173,6 +180,11 @@ GEM
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
     json (1.8.3)
+    jsonapi (0.1.1.beta6)
+      jsonapi-parser (= 0.1.1.beta3)
+      jsonapi-renderer (= 0.1.1.beta1)
+    jsonapi-parser (0.1.1.beta3)
+    jsonapi-renderer (0.1.1.beta1)
     kaminari (0.17.0)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -404,6 +416,7 @@ PLATFORMS
 
 DEPENDENCIES
   actionmailer-text
+  active_model_serializers
   awesome_print
   bourbon (= 5.0.0.beta.5)
   bullet

--- a/app/controllers/api/service_providers_controller.rb
+++ b/app/controllers/api/service_providers_controller.rb
@@ -1,0 +1,20 @@
+module Api
+  class ServiceProvidersController < ApplicationController
+    def index
+      render json: serialized_service_providers(approved_service_providers)
+    end
+
+    private
+
+    def serialized_service_providers(service_providers)
+      ActiveModel::Serializer::CollectionSerializer.new(
+        service_providers,
+        each_serializer: ServiceProviderSerializer
+      )
+    end
+
+    def approved_service_providers
+      ServiceProvider.where(active: true, approved: true)
+    end
+  end
+end

--- a/app/serializers/service_provider_serializer.rb
+++ b/app/serializers/service_provider_serializer.rb
@@ -1,0 +1,44 @@
+class ServiceProviderSerializer < ActiveModel::Serializer
+  attributes(
+    :issuer,
+    :agency,
+    :friendly_name,
+    :metadata_url,
+    :acs_url,
+    :assertion_consumer_logout_service_url,
+    :cert,
+    :block_encryption,
+    #:redirect_url,
+    #:return_to_sp_url,
+    #:logo,
+    #:attribute_bundle,
+    :updated_at,
+    :signature
+  )
+
+  def agency
+    object.name
+  end
+
+  def friendly_name
+    object.description
+  end
+
+  def cert
+    object.saml_client_cert
+  end
+
+  def updated_at
+    object.updated_at.iso8601
+  end
+
+  def signature
+    Digest::SHA256.hexdigest unique_identifier
+  end
+
+  private
+
+  def unique_identifier
+    object.id.to_s + object.issuer + object.created_at.to_s + object.updated_at.to_s
+  end
+end

--- a/bin/setup
+++ b/bin/setup
@@ -8,7 +8,7 @@ set -e
 
 # Set up Ruby dependencies via Bundler
 gem install bundler --conservative
-gem install foreman && gem update foreman
+gem install foreman --conservative && gem update foreman
 bundle check || bundle install
 
 # Set up database and add any development seed data

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,10 +14,18 @@ Rails.application.routes.draw do
     get 'timeout' => 'users/sessions#timeout'
   end
 
-  namespace :users do
-    resources :service_providers do
-    end
-  end
+  get '/users/service_providers' => 'users/service_providers#index', as: 'users_service_providers'
+  post '/users/service_providers' => 'users/service_providers#create'
+  get '/users/service_providers/new' => 'users/service_providers#new',
+      as: 'new_users_service_provider'
+  get '/users/service_providers/:id/edit' => 'users/service_providers#edit',
+      as: 'edit_users_service_provider'
+  get '/users/service_providers/:id' => 'users/service_providers#show', as: 'users_service_provider'
+  patch '/users/service_providers/:id' => 'users/service_providers#update'
+  put '/users/service_providers/:id' => 'users/service_providers#update'
+  delete '/users/service_providers/:id' => 'users/service_providers#destroy'
+
+  get '/api/service_providers' => 'api/service_providers#index'
 
   root to: 'home#index'
 end

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -6,7 +6,27 @@ if Rails.env.development? || Rails.env.test?
     task prime: "db:setup" do
       include FactoryGirl::Syntax::Methods
 
-      create(:user, email: "user@example.com")
+      user = create(:user, email: "user@example.com")
+
+      dashboard_saml_config = Saml::Config.new.settings
+      uuid = SecureRandom.uuid
+      create(:service_provider,
+        user: user,
+        issuer: uuid,
+        name: 'login.gov Dashboard',
+        description: 'user friendly login.gov dashboard',
+        metadata_url: "http://localhost:3001/api/service_providers/#{uuid}",
+        acs_url: 'http://localhost:3001/users/auth/saml/callback',
+        assertion_consumer_logout_service_url: 'http://localhost:3001/users/auth/saml/logout',
+        #sp_initiated_login_url: 'add once db is updated http://localhost:3001/users/auth/saml',
+        block_encryption: 'aes256-cbc',
+        saml_client_cert: dashboard_saml_config.certificate,
+        #attribute_bundle: add once db is updated [:email],
+        #logo: 'add once db updated svg string',
+        #return_to_sp_url: 'add once db is updated',
+        active: true,
+        approved: true
+      )
     end
   end
 end

--- a/spec/controllers/api/service_providers_controller_spec.rb
+++ b/spec/controllers/api/service_providers_controller_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe Api::ServiceProvidersController do
+  def response_from_json
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  describe '#index' do
+    it 'returns active, approved SPs' do
+      sp = create(:service_provider, active: true, approved: true)
+      serialized_sp = ServiceProviderSerializer.new(sp).to_h
+
+      get :index
+
+      expect(response_from_json).to include serialized_sp
+    end
+
+    it 'does not return un-approved SPs' do
+      sp = create(:service_provider, active: true, approved: false)
+      serialized_sp = ServiceProviderSerializer.new(sp).to_h
+
+      get :index
+
+      expect(response_from_json).to_not include serialized_sp
+    end
+
+    it 'does not return non-active SPs' do
+      sp = create(:service_provider, active: false, approved: true)
+      serialized_sp = ServiceProviderSerializer.new(sp).to_h
+
+      get :index
+
+      expect(response_from_json).to_not include serialized_sp
+    end
+  end
+end

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -1,0 +1,7 @@
+RSpec.configure do |config|
+  config.include Devise::Test::ControllerHelpers, type: :controller
+
+  config.before(:example, devise: true, type: :controller) do
+    @request.env['devise.mapping'] = Devise.mappings[:user]
+  end
+end


### PR DESCRIPTION
**Why**: Allows active, approved Service Providers to be published
for consumption by identity-idp