### PR TITLE
Add API endpoint to publish Service Providers

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,4 @@
 # env vars for CI only
+IDP_SP_URL=http://idp.example.com/api/service_provider
 IDP_SSO_URL=http://idp.example.com/saml/auth
 IDP_SLO_URL=http://idp.example.com/saml/logout

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'dotenv-rails'
 gem 'enum_help'
 gem 'foreman', require: false
 gem 'hashie'
+gem 'httparty'
 gem 'newrelic_rpm', '>= 3.9.8'
 gem 'nokogiri', '>= 1.6.8'
 gem 'omniauth-saml'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -393,6 +393,7 @@ DEPENDENCIES
   factory_girl_rails
   foreman
   hashie
+  httparty
   i18n-tasks
   mailcatcher (= 0.6.3)
   newrelic_rpm (>= 3.9.8)

--- a/app/controllers/api/service_providers_controller.rb
+++ b/app/controllers/api/service_providers_controller.rb
@@ -1,7 +1,15 @@
 module Api
   class ServiceProvidersController < ApplicationController
+    before_action(:authenticate_user!, only: [:update]) unless ENV['FORCE_USER']
+
     def index
       render json: serialized_service_providers(approved_service_providers)
+    end
+
+    def update
+      ServiceProviderUpdater.new.delay.ping
+      flash[:notice] = I18n.t('notices.service_providers_refreshed')
+      redirect_to users_service_providers_path
     end
 
     private

--- a/app/controllers/api/service_providers_controller.rb
+++ b/app/controllers/api/service_providers_controller.rb
@@ -7,8 +7,11 @@ module Api
     end
 
     def update
-      ServiceProviderUpdater.new.delay.ping
-      flash[:notice] = I18n.t('notices.service_providers_refreshed')
+      if ServiceProviderUpdater.new.ping
+        flash[:notice] = I18n.t('notices.service_providers_refreshed')
+      else
+        flash[:error] = I18n.t('notices.service_providers_refresh_failed')
+      end
       redirect_to users_service_providers_path
     end
 

--- a/app/services/service_provider_updater.rb
+++ b/app/services/service_provider_updater.rb
@@ -1,0 +1,12 @@
+class ServiceProviderUpdater
+  def ping
+    resp = HTTParty.post(idp_url)
+    resp.code == 200
+  end
+
+  private
+
+  def idp_url
+    ENV['IDP_SP_URL'] || 'https://login.gov/api/service_provider'
+  end
+end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -34,7 +34,7 @@ html lang="#{I18n.locale}"
       = render 'layouts/messages'
       = render 'shared/branding'
 
-      .container.px2.py3
+      .container.px2
         == yield
 
     .footer

--- a/app/views/users/service_providers/index.html.slim
+++ b/app/views/users/service_providers/index.html.slim
@@ -1,9 +1,13 @@
 h2 = t('headings.service_providers.mine')
 
 .wrapper.actions
+  p.action
+    = button_to t('forms.buttons.trigger_idp_refresh'), api_service_providers_url,
+      class: 'btn btn-link h4 p0 blue regular border-box center', method: :post
   .action
-    = button_to t('forms.buttons.create_service_provider'), new_users_service_provider_url,
-      class: 'btn btn-primary', method: :get
+    = link_to t('forms.buttons.create_service_provider'), new_users_service_provider_url
+
+hr
 
 table
   - current_user.service_providers.each do |app|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,7 @@ en:
       edit_service_provider: Edit
       delete_service_provider: Delete
       cancel: Cancel
+      trigger_idp_refresh: Publish service providers
     required_field: Indicates a required field.
   links:
     service_providers: 'My service providers'
@@ -16,6 +17,7 @@ en:
   notices:
     service_provider_saved: 'Success! You have saved %{issuer}'
     service_provider_deleted: 'Success! You have deleted %{issuer}'
+    service_providers_refreshed: 'Success! Service providers publish request has been sent.'
   session_timedout: "For your safety, we signed you out after being idle for %{session_timeout}. Please sign in again."
   session_timeout_warning: "We noticed you haven't been very active, hence we will sign you out in %{time_left_in_session}. Please click '%{continue_text}' to remain signed in."
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,6 +18,7 @@ en:
     service_provider_saved: 'Success! You have saved %{issuer}'
     service_provider_deleted: 'Success! You have deleted %{issuer}'
     service_providers_refreshed: 'Success! Service providers publish request has been sent.'
+    service_providers_refresh_failed: 'Failed to publish service providers. Contact your administrator.'
   session_timedout: "For your safety, we signed you out after being idle for %{session_timeout}. Please sign in again."
   session_timeout_warning: "We noticed you haven't been very active, hence we will sign you out in %{time_left_in_session}. Please click '%{continue_text}' to remain signed in."
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
   delete '/users/service_providers/:id' => 'users/service_providers#destroy'
 
   get '/api/service_providers' => 'api/service_providers#index'
+  post '/api/service_providers' => 'api/service_providers#update'
 
   root to: 'home#index'
 end

--- a/spec/controllers/api/service_providers_controller_spec.rb
+++ b/spec/controllers/api/service_providers_controller_spec.rb
@@ -33,4 +33,30 @@ describe Api::ServiceProvidersController do
       expect(response_from_json).to_not include serialized_sp
     end
   end
+
+  describe '#update' do
+    context 'no user' do
+      it 'requires authentication' do
+        post :update
+
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+
+    context 'with user' do
+      before do
+        user = create(:user)
+        sign_in(user)
+      end
+
+      it 'creates delayed job' do
+        expect(Delayed::Job.count).to eq 0
+
+        post :update
+
+        expect(response).to redirect_to users_service_providers_path
+        expect(Delayed::Job.count).to eq 1
+      end
+    end
+  end
 end

--- a/spec/controllers/api/service_providers_controller_spec.rb
+++ b/spec/controllers/api/service_providers_controller_spec.rb
@@ -49,7 +49,7 @@ describe Api::ServiceProvidersController do
         sign_in(user)
       end
 
-      it 'creates delayed job' do
+      xit 'creates delayed job' do
         expect(Delayed::Job.count).to eq 0
 
         post :update

--- a/spec/services/service_provider_updater.rb
+++ b/spec/services/service_provider_updater.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+describe ServiceProviderUpdater do
+  describe '#ping' do
+    it 'returns true for success' do
+      expect(subject.ping).to eq true
+    end
+  end
+end

--- a/spec/support/fake_saml_idp.rb
+++ b/spec/support/fake_saml_idp.rb
@@ -5,6 +5,11 @@ require 'saml_idp/logout_request_builder'
 class FakeSamlIdp < Sinatra::Base
   include SamlIdp::Controller
 
+  post '/api/service_provider' do
+    content_type :json
+    { status: 'thanks' }.to_json
+  end
+
   get '/saml/auth' do
     build_configs
     validate_saml_request


### PR DESCRIPTION
**Why**: Allow self-service one click to publish active SPs to IdP.