### PR TITLE
Re-enables signed requests with embedded signatures

### DIFF
--- a/lib/saml_config.rb
+++ b/lib/saml_config.rb
@@ -32,7 +32,7 @@ module Saml
         security: {
           authn_requests_signed: true,
           logout_requests_signed: true,
-          embed_sign: false,
+          embed_sign: true,
           digest_method: 'http://www.w3.org/2001/04/xmlenc#sha256',
           signature_method: 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
         }


### PR DESCRIPTION
### Why
Logout requests are not being signed since embed_sign is set to false

### How
Enables embed_sign