### PR TITLE
Include all ServiceProviders in feed

### DIFF
--- a/app/controllers/api/service_providers_controller.rb
+++ b/app/controllers/api/service_providers_controller.rb
@@ -25,7 +25,7 @@ module Api
     end
 
     def approved_service_providers
-      ServiceProvider.where(active: true)
+      ServiceProvider.all
     end
   end
 end

--- a/app/serializers/service_provider_serializer.rb
+++ b/app/serializers/service_provider_serializer.rb
@@ -12,7 +12,8 @@ class ServiceProviderSerializer < ActiveModel::Serializer
     #:logo,
     :attribute_bundle,
     :updated_at,
-    :signature
+    :signature,
+    :active
   )
 
   def agency

--- a/spec/controllers/api/service_providers_controller_spec.rb
+++ b/spec/controllers/api/service_providers_controller_spec.rb
@@ -24,13 +24,13 @@ describe Api::ServiceProvidersController do
       expect(response_from_json).to_not include serialized_sp
     end
 
-    it 'does not return non-active SPs' do
+    it 'includes non-active SPs' do
       sp = create(:service_provider, active: false, approved: true)
       serialized_sp = ServiceProviderSerializer.new(sp).to_h
 
       get :index
 
-      expect(response_from_json).to_not include serialized_sp
+      expect(response_from_json).to include serialized_sp
     end
   end
 


### PR DESCRIPTION
**Why**: Active flag filter prevents IdP from removing de-activated
SPs from the IdP cache.

**How**: Let the IdP do its own filtering, by
including the active flag as an attribute in feed.