### PR TITLE
Fix broken SP routes

### DIFF
--- a/app/controllers/users/service_providers_controller.rb
+++ b/app/controllers/users/service_providers_controller.rb
@@ -40,7 +40,7 @@ module Users
     end
 
     def service_provider
-      @service_provider ||= ServiceProvider.find_by(issuer: params[:id])
+      @service_provider ||= ServiceProvider.find(params[:id])
     end
 
     def authorize_approval

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -30,10 +30,6 @@ class ServiceProvider < ActiveRecord::Base
   end
   # rubocop:ensable MethodLength
 
-  def to_param
-    issuer
-  end
-
   def recently_approved?
     previous_changes.key?(:approved) && previous_changes[:approved].last == true
   end


### PR DESCRIPTION
**Why**: Since we're iterating on issuer formats (currently favoring an
URN), remove "issuer" as the ID in routing to avoid illegal URL
characters and broken routes.