### PR TITLE
Show all SPs to admins

### DIFF
--- a/app/controllers/users/service_providers_controller.rb
+++ b/app/controllers/users/service_providers_controller.rb
@@ -4,6 +4,7 @@ module Users
     before_action :authorize_approval, only: [:update]
 
     def index
+      @service_providers = ServiceProvider.all if current_user.admin?
     end
 
     def create

--- a/app/views/users/service_providers/index.html.slim
+++ b/app/views/users/service_providers/index.html.slim
@@ -15,3 +15,13 @@ table
       td = link_to(app.friendly_name, users_service_provider_path(app))
       td = app.issuer
       td = app.active? ? 'Active' : 'Inactive'
+
+- if current_user.admin?
+  h3 = 'All service providers'
+  table
+    - @service_providers.each do |sp|
+      tr
+        td = link_to(sp.friendly_name, users_service_provider_path(sp))
+        td = sp.agency.name
+        td = sp.issuer
+        td = sp.active? ? 'Active' : 'Inactive'

--- a/spec/features/service_providers_spec.rb
+++ b/spec/features/service_providers_spec.rb
@@ -45,6 +45,7 @@ feature 'ServiceProviders CRUD' do
     visit users_service_provider_path(app)
 
     expect(page).to have_content(app.friendly_name)
+    expect(page).to_not have_content('All service providers')
   end
 
   scenario 'Delete' do


### PR DESCRIPTION
**Why**: As an admin, I want to see all registered agency SPs,
including the ones I’ve created, so that I can easily view and manage
them on behalf of the agency.