### PR TITLE
Adds support for bastion host

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -13,6 +13,10 @@ require 'capistrano/rails'
 # support for new relic deploy updates
 require 'new_relic/recipes'
 
+# support for git
+require "capistrano/scm/git"
+install_plugin Capistrano::SCM::Git
+
 # support for whenever
 # require 'whenever/capistrano'
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,3 +1,4 @@
+require 'net/ssh/proxy/command'
 #################
 # GLOBAL CONFIG
 #################
@@ -18,7 +19,19 @@ set :passenger_restart_runner, :sequence
 set :rails_env, :production
 set :repo_url, 'https://github.com/18F/identity-dashboard.git'
 set :ssh_options, forward_agent: false, user: 'ubuntu'
+set :bastion_user, 'ubuntu'
 set :tmp_dir, '/tmp'
+
+set :ssh_options do
+  ssh_command = "ssh -A #{fetch(:bastion_user)}@#{fetch(:bastion_host)} -W %h:%p"
+    {
+    proxy: Net::SSH::Proxy::Command.new(ssh_command),
+    user: 'ubuntu',
+  }
+end
+
+server 'apps_host', roles: %w(web app db)
+
 
 #########
 # TASKS

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -19,19 +19,18 @@ set :passenger_restart_runner, :sequence
 set :rails_env, :production
 set :repo_url, 'https://github.com/18F/identity-dashboard.git'
 set :ssh_options, forward_agent: false, user: 'ubuntu'
-set :bastion_user, 'ubuntu'
+set :bastion_user, ENV['BASTION_USER'] || 'ubuntu'
 set :tmp_dir, '/tmp'
 
 set :ssh_options do
   ssh_command = "ssh -A #{fetch(:bastion_user)}@#{fetch(:bastion_host)} -W %h:%p"
-    {
+  {
     proxy: Net::SSH::Proxy::Command.new(ssh_command),
-    user: 'ubuntu',
+    user: 'ubuntu'
   }
 end
 
 server 'apps_host', roles: %w(web app db)
-
 
 #########
 # TASKS

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -18,10 +18,9 @@ set :passenger_restart_wait, 5
 set :passenger_restart_runner, :sequence
 set :rails_env, :production
 set :repo_url, 'https://github.com/18F/identity-dashboard.git'
-set :ssh_options, forward_agent: false, user: 'ubuntu'
-set :bastion_user, ENV['BASTION_USER'] || 'ubuntu'
 set :tmp_dir, '/tmp'
 
+set :bastion_user, ENV['BASTION_USER'] || 'ubuntu'
 set :ssh_options do
   ssh_command = "ssh -A #{fetch(:bastion_user)}@#{fetch(:bastion_host)} -W %h:%p"
   {

--- a/config/deploy/demo.rb
+++ b/config/deploy/demo.rb
@@ -1,1 +1,1 @@
-server 'dashboard.demo.login.gov', roles: %w(web app db)
+set :bastion_host, 'jumphost.demo.login.gov'

--- a/config/deploy/dev.rb
+++ b/config/deploy/dev.rb
@@ -1,1 +1,1 @@
-server 'dashboard.dev.login.gov', roles: %w(web app db)
+set :bastion_host, 'jumphost.dev.login.gov'

--- a/config/deploy/int.rb
+++ b/config/deploy/int.rb
@@ -1,1 +1,1 @@
-server 'dashboard.int.login.gov', roles: %w(web app db)
+set :bastion_host, 'jumphost.int.login.gov'

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,1 +1,1 @@
-server 'dashboard.qa.login.gov', roles: %w(web app db)
+set :bastion_host, 'jumphost.qa.login.gov'

--- a/config/deploy/tf.rb
+++ b/config/deploy/tf.rb
@@ -1,1 +1,1 @@
-server 'dashboard.tf.login.gov', roles: %w(app web db)
+set :bastion_host, 'jumphost.tf.login.gov'


### PR DESCRIPTION
Why
To permit developers to deploy via capistrano

How
Enable SSH proxy (bastion) host