### PR TITLE
Enforce trailing comma via rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -201,7 +201,7 @@ Style/TrailingCommaInArguments:
   # parenthesized method calls where each argument is on its own line.
   # If `consistent_comma`, the cop requires a comma after the last argument,
   # for all parenthesized method calls with arguments.
-  EnforcedStyleForMultiline: no_comma
+  EnforcedStyleForMultiline: comma
   SupportedStyles:
     - comma
     - consistent_comma

--- a/app/controllers/api/service_providers_controller.rb
+++ b/app/controllers/api/service_providers_controller.rb
@@ -20,7 +20,7 @@ module Api
     def serialized_service_providers(service_providers)
       ActiveModel::Serializer::CollectionSerializer.new(
         service_providers,
-        each_serializer: ServiceProviderSerializer
+        each_serializer: ServiceProviderSerializer,
       )
     end
 

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -54,7 +54,7 @@ module Users
     def idp_logout_request
       logout_request = OneLogin::RubySaml::SloLogoutrequest.new(
         params[:SAMLRequest],
-        settings: saml_settings
+        settings: saml_settings,
       )
       if logout_request.is_valid?
         redirect_to_idp_logout(logout_request)
@@ -73,7 +73,7 @@ module Users
         saml_settings,
         logout_request.id,
         nil,
-        RelayState: params[:RelayState]
+        RelayState: params[:RelayState],
       )
       redirect_to logout_response
     end

--- a/app/controllers/users/service_providers_controller.rb
+++ b/app/controllers/users/service_providers_controller.rb
@@ -103,7 +103,7 @@ module Users
         :return_to_sp_url,
         :saml_client_cert,
         :sp_initiated_login_url,
-        attribute_bundle: []
+        attribute_bundle: [],
       )
     end
     # rubocop:enable MethodLength

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -22,7 +22,7 @@ module Users
     def timeout
       flash[:notice] = I18n.t(
         'session_timedout',
-        session_timeout: distance_of_time_in_words(Devise.timeout_in)
+        session_timeout: distance_of_time_in_words(Devise.timeout_in),
       )
       redirect_to root_url
     end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -6,7 +6,7 @@ class UserMailer < ApplicationMailer
   def welcome_new_user(user)
     mail(
       to: user.email,
-      subject: I18n.t('mailer.welcome.subject')
+      subject: I18n.t('mailer.welcome.subject'),
     )
   end
 
@@ -14,7 +14,7 @@ class UserMailer < ApplicationMailer
     @service_provider = app
     mail(
       to: admin_email_address,
-      subject: I18n.t('mailer.new_service_provider.subject', id: app.issuer)
+      subject: I18n.t('mailer.new_service_provider.subject', id: app.issuer),
     )
   end
 
@@ -22,7 +22,7 @@ class UserMailer < ApplicationMailer
     @service_provider = app
     mail(
       to: app.user.email,
-      subject: I18n.t('mailer.new_service_provider.subject', id: app.issuer)
+      subject: I18n.t('mailer.new_service_provider.subject', id: app.issuer),
     )
   end
 
@@ -30,7 +30,7 @@ class UserMailer < ApplicationMailer
     @service_provider = app
     mail(
       to: admin_email_address,
-      subject: I18n.t('mailer.approved_service_provider.subject', id: app.issuer)
+      subject: I18n.t('mailer.approved_service_provider.subject', id: app.issuer),
     )
   end
 
@@ -38,7 +38,7 @@ class UserMailer < ApplicationMailer
     @service_provider = app
     mail(
       to: app.user.email,
-      subject: I18n.t('mailer.approved_service_provider.subject', id: app.issuer)
+      subject: I18n.t('mailer.approved_service_provider.subject', id: app.issuer),
     )
   end
 end

--- a/app/serializers/service_provider_serializer.rb
+++ b/app/serializers/service_provider_serializer.rb
@@ -14,7 +14,7 @@ class ServiceProviderSerializer < ActiveModel::Serializer
     :return_to_sp_url,
     :signature,
     :sp_initiated_login_url,
-    :updated_at
+    :updated_at,
   )
 
   def agency

--- a/app/services/deploy_status_checker.rb
+++ b/app/services/deploy_status_checker.rb
@@ -76,9 +76,7 @@ class DeployStatusChecker
   def load_status(deploy)
     uri = URI.join(deploy.host, '/api/deploy.json')
 
-    Net::HTTP.start(uri.host, uri.port,
-                    use_ssl: uri.scheme == 'https',
-                    open_timeout: 2) do |http|
+    Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', open_timeout: 2) do |http|
       request = Net::HTTP::Get.new(uri.request_uri)
       basic_auth(request)
       http.request(request)

--- a/lib/saml_config.rb
+++ b/lib/saml_config.rb
@@ -15,7 +15,7 @@ module Saml
         certificate: ENV.fetch('SP_CERTIFICATE', saml_env_config[:sp_certificate]),
         private_key: OpenSSL::PKey::RSA.new(
           ENV.fetch('SP_PRIVATE_KEY', saml_env_config[:sp_private_key]),
-          ENV.fetch('SP_PRIVATE_KEY_PASSWORD', saml_env_config[:sp_private_key_password])
+          ENV.fetch('SP_PRIVATE_KEY_PASSWORD', saml_env_config[:sp_private_key_password]),
         ).to_s,
         allowed_clock_drift: 5.minutes,
         authn_context: 'http://idmanagement.gov/ns/assurance/loa/1',
@@ -27,7 +27,7 @@ module Saml
           embed_sign: false,
           digest_method: 'http://www.w3.org/2001/04/xmlenc#sha256',
           signature_method: 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
-        }
+        },
       )
     end
     # rubocop:enable AbcSize, MethodLength

--- a/spec/support/fake_saml_idp.rb
+++ b/spec/support/fake_saml_idp.rb
@@ -49,7 +49,7 @@ class FakeSamlIdp < Sinatra::Base
       SamlIdp.config.base_saml_location,
       'foo/bar/logout',
       user.uuid,
-      OpenSSL::Digest::SHA256
+      OpenSSL::Digest::SHA256,
     )
   end
 


### PR DESCRIPTION
**Why**: It's stylish and how we write ruby in the idp app