### PR TITLE
Move agency back to being a string

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -14,6 +14,7 @@ engines:
       - javascript
     exclude_paths:
     - 'spec/**/*'
+    - 'db/migrate/*'
   eslint:
     enabled: true
   fixme:

--- a/app/controllers/users/service_providers_controller.rb
+++ b/app/controllers/users/service_providers_controller.rb
@@ -90,7 +90,7 @@ module Users
       params.require(:service_provider).permit(
         :acs_url,
         :active,
-        :agency_id,
+        :agency,
         :approved,
         :assertion_consumer_logout_service_url,
         :block_encryption,

--- a/app/models/agency.rb
+++ b/app/models/agency.rb
@@ -1,2 +1,0 @@
-class Agency < ActiveRecord::Base
-end

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -1,6 +1,5 @@
 class ServiceProvider < ActiveRecord::Base
   belongs_to :user
-  belongs_to :agency
 
   enum block_encryption: { 'aes256-cbc' => 1 }
 

--- a/app/serializers/service_provider_serializer.rb
+++ b/app/serializers/service_provider_serializer.rb
@@ -17,10 +17,6 @@ class ServiceProviderSerializer < ActiveModel::Serializer
     :updated_at,
   )
 
-  def agency
-    object.agency.name
-  end
-
   def cert
     object.saml_client_cert
   end

--- a/app/views/users/service_providers/_form.html.slim
+++ b/app/views/users/service_providers/_form.html.slim
@@ -6,7 +6,7 @@
 = form.input :friendly_name
 = form.input :description
 = form.input :issuer
-= form.association :agency
+= form.input :agency
 = form.input :acs_url, label: 'Assertion Consumer Service URL'
 = form.input :assertion_consumer_logout_service_url, label: 'Assertion Consumer Logout Service URL'
 = form.input :sp_initiated_login_url, label: 'SP Initiated Login URL'

--- a/app/views/users/service_providers/show.html.slim
+++ b/app/views/users/service_providers/show.html.slim
@@ -17,7 +17,7 @@ table.horizontal-headers
     td.issuer = service_provider.issuer
   tr
     th Agency
-    td.agency = service_provider.agency.name
+    td.agency = service_provider.agency
   tr
     th Logo
     td.logo = ''

--- a/db/migrate/20170301235601_remove_agencies.rb
+++ b/db/migrate/20170301235601_remove_agencies.rb
@@ -1,0 +1,38 @@
+class RemoveAgencies < ActiveRecord::Migration
+  class ServiceProvider < ActiveRecord::Base
+  end
+
+  class Agency < ActiveRecord::Base
+  end
+
+  def up
+    add_column :service_providers, :agency, :string
+
+    ServiceProvider.where.not(agency_id: nil).each do |sp|
+      agency = Agency.find(sp.agency_id)
+      sp.update_attributes(agency: agency.name)
+    end
+
+    remove_column :service_providers, :agency_id
+    drop_table :agencies
+  end
+
+  def down
+    create_table :agencies do |t|
+      t.string :name, null: false
+      t.timestamps
+    end
+    add_index :agencies, :name, unique: true
+
+    add_column :service_providers, :agency_id, :integer
+
+    ServiceProvider.where.not(agency: nil).each do |sp|
+      agency = Agency.find_or_create_by(name: sp.agency)
+      sp.update_attributes(agency_id: agency.id)
+    end
+
+    remove_column :service_providers, :agency
+    add_foreign_key :service_providers, :agencies
+    change_column_null :service_providers, :agency_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,18 +11,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170301184735) do
+ActiveRecord::Schema.define(version: 20170301235601) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "agencies", force: :cascade do |t|
-    t.string   "name",       null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  add_index "agencies", ["name"], name: "index_agencies_on_name", unique: true, using: :btree
 
   create_table "delayed_jobs", force: :cascade do |t|
     t.integer  "priority",   default: 0, null: false
@@ -66,9 +58,9 @@ ActiveRecord::Schema.define(version: 20170301184735) do
     t.boolean  "approved",                              default: false, null: false
     t.text     "sp_initiated_login_url"
     t.text     "return_to_sp_url"
-    t.integer  "agency_id",                                             null: false
     t.json     "attribute_bundle"
     t.string   "redirect_uri"
+    t.string   "agency"
   end
 
   add_index "service_providers", ["issuer"], name: "index_service_providers_on_issuer", unique: true, using: :btree
@@ -91,5 +83,4 @@ ActiveRecord::Schema.define(version: 20170301184735) do
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["uuid"], name: "index_users_on_uuid", unique: true, using: :btree
 
-  add_foreign_key "service_providers", "agencies"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,7 +5,3 @@
 #
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
-
-%w(DHS GSA RRB).each do |str|
-  Agency.find_or_create_by(name: str)
-end

--- a/spec/factories/agency.rb
+++ b/spec/factories/agency.rb
@@ -1,5 +1,0 @@
-FactoryGirl.define do
-  factory :agency do
-    sequence(:name) { |n| "test-agency-#{n}" }
-  end
-end

--- a/spec/factories/service_providers.rb
+++ b/spec/factories/service_providers.rb
@@ -1,9 +1,9 @@
 FactoryGirl.define do
   factory :service_provider do
+    agency 'Test agency'
     sequence(:friendly_name) { |n| "test-service_provider-#{n}" }
     sequence(:issuer) { |n| "test-service_provider-#{n}" }
     sequence(:description) { |n| "test service_provider description #{n}" }
     association :user, factory: :user
-    association :agency, factory: :agency
   end
 end

--- a/spec/features/service_providers_spec.rb
+++ b/spec/features/service_providers_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 feature 'ServiceProviders CRUD' do
   scenario 'Create' do
     user = create(:user)
-    agency = create(:agency)
     login_as(user)
 
     visit new_users_service_provider_path
@@ -12,7 +11,7 @@ feature 'ServiceProviders CRUD' do
 
     fill_in 'Friendly name', with: 'test service_provider'
     fill_in 'Issuer', with: 'test service_provider'
-    select agency.name, from: 'service_provider[agency_id]'
+    fill_in 'Agency', with: 'Test agency'
     check 'email'
     check 'first_name'
     click_on 'Create'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -18,7 +18,6 @@ RSpec.configure do |config|
   config.include Warden::Test::Helpers
 
   config.before(:suite) do
-    Rails.application.load_seed
     Warden.test_mode!
   end
 


### PR DESCRIPTION
**Why**: SPs will now belong to an Organization, which will be how we
group them. This model was added for grouping purposes. See convo at
https://github.com/18F/identity-dashboard/pull/46#discussion_r96485084