### PR TITLE
Remove `FORCE_USER` references

### DIFF
--- a/app/controllers/api/service_providers_controller.rb
+++ b/app/controllers/api/service_providers_controller.rb
@@ -1,6 +1,6 @@
 module Api
   class ServiceProvidersController < ApplicationController
-    before_action(:authenticate_user!, only: [:update]) unless Figaro.env.FORCE_USER
+    before_action(:authenticate_user!, only: [:update])
 
     def index
       render json: serialized_service_providers(approved_service_providers)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,18 +5,6 @@ class ApplicationController < ActionController::Base
 
   rescue_from Pundit::NotAuthorizedError, with: :render_401
 
-  def current_user
-    if Figaro.env.FORCE_USER
-      User.find(Figaro.env.FORCE_USER)
-    else
-      super
-    end
-  end
-
-  def user_signed_in?
-    Figaro.env.FORCE_USER.present? || super
-  end
-
   def new_session_path(_scope)
     new_user_session_path
   end

--- a/app/controllers/authenticated_controller.rb
+++ b/app/controllers/authenticated_controller.rb
@@ -1,3 +1,3 @@
 class AuthenticatedController < ApplicationController
-  before_action :authenticate_user! unless Figaro.env.FORCE_USER
+  before_action :authenticate_user!
 end


### PR DESCRIPTION
**Why**: We do not need this because users can auth with Login.gov