### PR TITLE
Only run simplecov in CI env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,10 @@ script:
   - make test
   - bundle exec codeclimate-test-reporter
 env:
-  - RACK_ENV=test
-  - RAILS_ENV=test
+  global:
+    - RACK_ENV=test
+    - RAILS_ENV=test
+    - COVERAGE=true
 addons:
   postgresql: 9.3
   code_climate:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ script:
   - bundle exec codeclimate-test-reporter
 env:
   global:
-    - RACK_ENV=test
-    - RAILS_ENV=test
     - COVERAGE=true
 addons:
   postgresql: 9.3

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -16,7 +16,6 @@ RSpec.configure do |config|
   config.include Warden::Test::Helpers
 
   config.before(:suite) do
-    Rails.application.load_seed
     Warden.test_mode!
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
-require 'simplecov'
-SimpleCov.start 'rails' do
-  add_filter '/config/'
+if ENV['COVERAGE']
+  require 'simplecov'
+  SimpleCov.start 'rails' do
+    add_filter '/config/'
+  end
 end
 
 ENV['RAILS_ENV'] ||= 'test'


### PR DESCRIPTION
**Why**:
* When running `rpsec spec/ --profile`, i18n-tasks was slowest file
* Ran 3 times, each time file took ~2 seconds to run
* Upon investigation, this appears to relate to Simplecov
* See https://github.com/glebm/i18n-tasks/issues/221
* Also https://github.com/colszowka/simplecov/issues/404
* Since there is no proposed solution at the moment (slowness appears to
  be coming from `Coverage`, which is part of the Ruby stdlib), the
  short term solution is to only run Simplecov on Travis, where required
* New timing for i18n-tasks: under .2 seconds!!!

Before:

```
Top 10 slowest example groups:
  I18n
    1.8 seconds average (3.59 seconds / 2 examples) ./spec/i18n_spec.rb:4
  Users::ServiceProviders
    0.17479 seconds average (1.22 seconds / 7 examples) ./spec/requests/service_providers_spec.rb:3
```

After:

```
Top 10 slowest example groups:
  Users::ServiceProviders
    0.16671 seconds average (1.17 seconds / 7 examples) ./spec/requests/service_providers_spec.rb:3
  I18n
    0.14545 seconds average (0.29089 seconds / 2 examples) ./spec/i18n_spec.rb:4
```