### PR TITLE
Do not show users who are already in user groups in form

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ActiveRecord::Base
   after_create :send_welcome
 
   scope :sorted, -> { order(email: :asc) }
+  scope :without_user_group, -> { where(user_group: nil) }
 
   def create_uuid
     self.uuid = SecureRandom.uuid unless uuid.present?

--- a/app/views/user_groups/_form.html.slim
+++ b/app/views/user_groups/_form.html.slim
@@ -1,3 +1,3 @@
 = form.input :name
 = form.input :description
-= form.association :users, label_method: :to_s, collection: User.sorted
+= form.association :users, label_method: :to_s, collection: User.without_user_group.sorted

--- a/spec/features/user_groups_spec.rb
+++ b/spec/features/user_groups_spec.rb
@@ -20,6 +20,19 @@ feature 'User groups CRUD' do
     expect(page).to have_content(user.email)
   end
 
+  context 'User already in a user group' do
+    scenario 'User does not show up as option for new group' do
+      admin = create(:admin)
+      user = create(:user)
+      _user_group = create(:user_group, users: [user])
+
+      login_as(admin)
+      visit new_user_group_path
+
+      expect(page).not_to have_content(user.email)
+    end
+  end
+
   scenario 'Update' do
     admin = create(:admin)
     org = create(:user_group)


### PR DESCRIPTION
**Why**: Users can only belong to one user group. If we add them to a
second one, that will automatically un-assign them from their first user
group, which is unexpected. More expected to just not show them as an
option. Also will have side benefit of making list of possible users
shorter.