### PR TITLE
Show users who are already in a user group when editing

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,10 @@ class User < ActiveRecord::Base
   after_create :send_welcome
 
   scope :sorted, -> { order(email: :asc) }
-  scope :without_user_group, -> { where(user_group: nil) }
+
+  def self.without_other_user_group(user_group_id: nil)
+    where(user_group_id: [nil, user_group_id])
+  end
 
   def create_uuid
     self.uuid = SecureRandom.uuid unless uuid.present?

--- a/app/views/user_groups/_form.html.slim
+++ b/app/views/user_groups/_form.html.slim
@@ -1,3 +1,5 @@
 = form.input :name
 = form.input :description
-= form.association :users, label_method: :to_s, collection: User.without_user_group.sorted
+= form.association :users,
+  label_method: :to_s,
+  collection: User.without_other_user_group(user_group_id: @user_group.id).sorted

--- a/spec/features/user_groups_spec.rb
+++ b/spec/features/user_groups_spec.rb
@@ -31,6 +31,17 @@ feature 'User groups CRUD' do
 
       expect(page).not_to have_content(user.email)
     end
+
+    scenario 'User does show up in user group that they are assigned to' do
+      admin = create(:admin)
+      user = create(:user)
+      user_group = create(:user_group, users: [user])
+
+      login_as(admin)
+      visit edit_user_group_path(user_group)
+
+      expect(page).to have_content(user.email)
+    end
   end
 
   scenario 'Update' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,7 +18,7 @@ describe User do
         user_group = create(:user_group, users: users_in_group)
 
         expect(User.without_other_user_group(user_group_id: user_group.id)).to match_array(
-          users_in_group + [user_without_group]
+          users_in_group + [user_without_group],
         )
       end
     end
@@ -29,7 +29,7 @@ describe User do
         user_without_group = create(:user)
 
         expect(User.without_other_user_group(user_group_id: nil)).to match_array(
-          [user_without_group]
+          [user_without_group],
         )
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,6 +9,32 @@ describe User do
 
   let(:user) { build(:user) }
 
+  describe '.without_other_user_group' do
+    context 'user group id passed in' do
+      it 'returns users without a user group or with user group id passed in' do
+        _user_in_other_user_group = create(:user, user_group: create(:user_group))
+        user_without_group = create(:user)
+        users_in_group = create_list(:user, 2)
+        user_group = create(:user_group, users: users_in_group)
+
+        expect(User.without_other_user_group(user_group_id: user_group.id)).to match_array(
+          users_in_group + [user_without_group]
+        )
+      end
+    end
+
+    context 'no user group id passed in' do
+      it 'returns all users without a user group' do
+        _user_in_other_user_group = create(:user, user_group: create(:user_group))
+        user_without_group = create(:user)
+
+        expect(User.without_other_user_group(user_group_id: nil)).to match_array(
+          [user_without_group]
+        )
+      end
+    end
+  end
+
   describe '#uuid' do
     it 'assigns uuid on create' do
       user.save


### PR DESCRIPTION
* There was a bug where we were showing only users without a user group
* This lead to an issue where users in a user group were not showing
  when editing that user group, leading to them being unassigned
* Now this is fixed and I added a regression test