### PR TITLE
Add ability to set logo name when adding SP

### DIFF
--- a/app/controllers/service_providers_controller.rb
+++ b/app/controllers/service_providers_controller.rb
@@ -96,7 +96,7 @@ class ServiceProvidersController < AuthenticatedController
       :description,
       :friendly_name,
       :issuer,
-      # :logo,
+      :logo,
       :metadata_url,
       :redirect_uri,
       :return_to_sp_url,

--- a/app/helpers/service_provider_helper.rb
+++ b/app/helpers/service_provider_helper.rb
@@ -1,0 +1,6 @@
+module ServiceProviderHelper
+  def sp_logo_path(file_name)
+    'https://raw.githubusercontent.com/18F/identity-idp/master/app/assets/images/sp-logos/' +
+    file_name
+  end
+end

--- a/app/helpers/service_provider_helper.rb
+++ b/app/helpers/service_provider_helper.rb
@@ -1,6 +1,7 @@
 module ServiceProviderHelper
   def sp_logo_path(file_name)
+    file = file_name || 'generic.svg'
     'https://raw.githubusercontent.com/18F/identity-idp/master/app/assets/images/sp-logos/' +
-      file_name
+      file
   end
 end

--- a/app/helpers/service_provider_helper.rb
+++ b/app/helpers/service_provider_helper.rb
@@ -1,6 +1,6 @@
 module ServiceProviderHelper
   def sp_logo_path(file_name)
     'https://raw.githubusercontent.com/18F/identity-idp/master/app/assets/images/sp-logos/' +
-    file_name
+      file_name
   end
 end

--- a/app/views/service_providers/_form.html.slim
+++ b/app/views/service_providers/_form.html.slim
@@ -14,6 +14,7 @@
 = form.input :description
 = form.input :issuer
 = form.association :agency
+= form.input :logo
 = form.input :acs_url
 = form.input :assertion_consumer_logout_service_url
 = form.input :sp_initiated_login_url

--- a/app/views/service_providers/show.html.slim
+++ b/app/views/service_providers/show.html.slim
@@ -21,11 +21,12 @@ table.horizontal-headers
     th = t('simple_form.labels.service_provider.agency')
     td.agency = service_provider.agency.name
   tr
+    th = t('simple_form.labels.service_provider.logo')
+    td.logo
+      = image_tag("https://raw.githubusercontent.com/18F/identity-idp/master/app/assets/images/sp-logos/#{service_provider.logo}")
+  tr
     th = t('simple_form.labels.service_provider.user_group')
     td.user_group = service_provider.user_group
-  tr
-    th = t('simple_form.labels.service_provider.logo')
-    td.logo = ''
   tr
     th = t('simple_form.labels.service_provider.acs_url')
     td.acs_url = service_provider.acs_url

--- a/app/views/service_providers/show.html.slim
+++ b/app/views/service_providers/show.html.slim
@@ -23,7 +23,7 @@ table.horizontal-headers
   tr
     th = t('simple_form.labels.service_provider.logo')
     td.logo
-      = image_tag("https://raw.githubusercontent.com/18F/identity-idp/master/app/assets/images/sp-logos/#{service_provider.logo}")
+      = image_tag(sp_logo_path(service_provider.logo))
   tr
     th = t('simple_form.labels.service_provider.user_group')
     td.user_group = service_provider.user_group

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -92,12 +92,8 @@ search:
 # - '{devise,simple_form}.*'
 
 ## Consider these keys used:
-# ignore_unused:
-# - 'activerecord.attributes.*'
-# - '{devise,kaminari,will_paginate}.*'
-# - 'simple_form.{yes,no}'
-# - 'simple_form.{placeholders,hints,labels}.*'
-# - 'simple_form.{error_notification,required}.:'
+ignore_unused:
+- 'simple_form.{placeholders,hints,labels}.*'
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -6,6 +6,7 @@ SimpleForm.setup do |config|
 
   config.wrappers :base do |b|
     b.use :html5
+    b.use :hint,  wrap_with: { tag: :span, class: :hint }
     b.use :input, class: 'field'
   end
 

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -15,7 +15,7 @@ en:
         description: Description
         friendly_name: Friendly name
         issuer: Issuer
-        logo: 'Logo (make sure you include the file name of a file in https://github.com/18F/identity-idp/tree/master/app/assets/images/sp-logos)'
+        logo: Logo
         redirect_uri: Redirect URI (for OpenID Connect)
         return_to_sp_url: Return to SP URL
         saml_client_cert: SAML Client Cert (PEM encoded)

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -1,6 +1,9 @@
 ---
 en:
   simple_form:
+    placeholders:
+      service_provider:
+       logo: 'generic.svg'
     labels:
       service_provider:
         acs_url: Assertion Consumer Service URL
@@ -12,7 +15,7 @@ en:
         description: Description
         friendly_name: Friendly name
         issuer: Issuer
-        logo: Logo
+        logo: 'Logo (make sure you include the file name of a file in https://github.com/18F/identity-idp/tree/master/app/assets/images/sp-logos)'
         redirect_uri: Redirect URI (for OpenID Connect)
         return_to_sp_url: Return to SP URL
         saml_client_cert: SAML Client Cert (PEM encoded)

--- a/db/migrate/20170330181317_add_logo_to_service_providers.rb
+++ b/db/migrate/20170330181317_add_logo_to_service_providers.rb
@@ -1,0 +1,5 @@
+class AddLogoToServiceProviders < ActiveRecord::Migration
+  def change
+    add_column :service_providers, :logo, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170307195917) do
+ActiveRecord::Schema.define(version: 20170330181317) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,6 +60,7 @@ ActiveRecord::Schema.define(version: 20170307195917) do
     t.json     "attribute_bundle"
     t.string   "redirect_uri"
     t.integer  "user_group_id"
+    t.string   "logo"
   end
 
   add_index "service_providers", ["issuer"], name: "index_service_providers_on_issuer", unique: true, using: :btree

--- a/spec/features/service_providers_spec.rb
+++ b/spec/features/service_providers_spec.rb
@@ -12,8 +12,9 @@ feature 'Service Providers CRUD' do
       expect(page).to_not have_content('Approved')
 
       fill_in 'Friendly name', with: 'test service_provider'
-      fill_in 'Issuer', with: 'test service_provider'
+      fill_in 'service_provider_issuer', with: 'test service_provider'
       select agency.name, from: 'service_provider[agency_id]'
+      fill_in 'service_provider_logo', with: 'test.png'
       check 'email'
       check 'first_name'
       click_on 'Create'
@@ -23,6 +24,7 @@ feature 'Service Providers CRUD' do
         expect(page).to have_content('test service_provider')
         expect(page).to have_content('email')
         expect(page).to have_content('first_name')
+        expect(page).to have_css('img[src*=sp-logos]')
       end
     end
 

--- a/spec/helpers/service_provider_helper_spec.rb
+++ b/spec/helpers/service_provider_helper_spec.rb
@@ -7,7 +7,7 @@ describe ServiceProviderHelper do
         file = 'test.png'
 
         expect(sp_logo_path(file)).to match(
-          /test.png/
+          /test.png/,
         )
       end
     end
@@ -17,7 +17,7 @@ describe ServiceProviderHelper do
         file = nil
 
         expect(sp_logo_path(file)).to match(
-          /generic.svg/
+          /generic.svg/,
         )
       end
     end

--- a/spec/helpers/service_provider_helper_spec.rb
+++ b/spec/helpers/service_provider_helper_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe ServiceProviderHelper do
+  describe '#sp_logo_path' do
+    context 'file name is present' do
+      it 'returns the logo' do
+        file = 'test.png'
+
+        expect(sp_logo_path(file)).to match(
+          /test.png/
+        )
+      end
+    end
+
+    context 'file name is nil' do
+      it 'returns generic logo' do
+        file = nil
+
+        expect(sp_logo_path(file)).to match(
+          /generic.svg/
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
**WHY**: Agencies can add logos!

When logo name is invalid:

![screen shot 2017-03-30 at 11 56 40 am](https://cloud.githubusercontent.com/assets/601515/24521623/a791260c-1541-11e7-9acf-5d60181ec5a0.png)

When logo name is valid:

![screen shot 2017-03-30 at 11 57 40 am](https://cloud.githubusercontent.com/assets/601515/24521638/b455d7a2-1541-11e7-90d8-8d17d0b8ad31.png)

