### PR TITLE
Added select for identity protocol to service providers

### DIFF
--- a/app/controllers/service_providers_controller.rb
+++ b/app/controllers/service_providers_controller.rb
@@ -103,6 +103,7 @@ class ServiceProvidersController < AuthenticatedController
       :saml_client_cert,
       :sp_initiated_login_url,
       :user_group_id,
+      :identity_protocol,
       attribute_bundle: [],
     )
   end

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -4,6 +4,7 @@ class ServiceProvider < ActiveRecord::Base
   belongs_to :user_group
 
   enum block_encryption: { 'aes256-cbc' => 1 }
+  enum identity_protocol: { openid_connect: 0, saml: 1 }
 
   validates :issuer, presence: true, uniqueness: true
   validates :agency, presence: true

--- a/app/views/service_providers/_form.html.slim
+++ b/app/views/service_providers/_form.html.slim
@@ -3,6 +3,8 @@
 - if current_user.admin?
   = form.input :approved, as: :radio_buttons
 
+= form.input :identity_protocol, as: :radio_buttons
+
 = form.association :user_group,
   as: :collection_select,
   collection: current_user.scoped_user_groups,

--- a/app/views/service_providers/show.html.slim
+++ b/app/views/service_providers/show.html.slim
@@ -9,6 +9,9 @@ h2 = t('headings.service_providers.show', friendly_name: service_provider.friend
 
 table.horizontal-headers
   tr
+    th = t('simple_form.labels.service_provider.identity_protocol')
+    td.identity_protocol = service_provider.identity_protocol.humanize
+  tr
     th = t('simple_form.labels.service_provider.friendly_name')
     td.friendly_name = service_provider.friendly_name
   tr

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -21,6 +21,7 @@ en:
         saml_client_cert: SAML Client Cert (PEM encoded)
         sp_initiated_login_url: SP Initiated Login URL
         user_group: User Group
+        identity_protocol: Identity Protocol
       user:
         admin: Admin?
         email: Email

--- a/db/migrate/20170509155224_add_auth_types_to_service_providers.rb
+++ b/db/migrate/20170509155224_add_auth_types_to_service_providers.rb
@@ -1,0 +1,5 @@
+class AddAuthTypesToServiceProviders < ActiveRecord::Migration
+  def change
+    add_column :service_providers, :identity_protocol, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170330181317) do
+ActiveRecord::Schema.define(version: 20170509155224) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -61,6 +61,7 @@ ActiveRecord::Schema.define(version: 20170330181317) do
     t.string   "redirect_uri"
     t.integer  "user_group_id"
     t.string   "logo"
+    t.integer  "identity_protocol",                     default: 0
   end
 
   add_index "service_providers", ["issuer"], name: "index_service_providers_on_issuer", unique: true, using: :btree

--- a/spec/features/service_providers_spec.rb
+++ b/spec/features/service_providers_spec.rb
@@ -25,6 +25,7 @@ feature 'Service Providers CRUD' do
         expect(page).to have_content('email')
         expect(page).to have_content('first_name')
         expect(page).to have_css('img[src*=sp-logos]')
+        expect(page).to have_content('Openid connect')
       end
     end
 
@@ -75,6 +76,7 @@ feature 'Service Providers CRUD' do
 
       fill_in 'Friendly name', with: 'change service_provider name'
       fill_in 'Description', with: 'app description foobar'
+      choose 'Saml'
       check 'last_name'
       click_on 'Update'
 
@@ -83,6 +85,7 @@ feature 'Service Providers CRUD' do
         expect(page).to have_content('app description foobar')
         expect(page).to have_content('change service_provider name')
         expect(page).to have_content('last_name')
+        expect(page).to have_content('Identity ProtocolSaml')
       end
     end
 


### PR DESCRIPTION
  Allows users to set SAML or OpenId Connect
  Will change which fields are shown in future PR
<img width="560" alt="identity_dashboard" src="https://cloud.githubusercontent.com/assets/5296248/25916855/1cb59e14-3594-11e7-9df9-f9ef13723513.png">
