### PR TITLE
Show appropriate fields based on id protocol

### DIFF
--- a/app/assets/javascripts/app/service-provider-form.js
+++ b/app/assets/javascripts/app/service-provider-form.js
@@ -1,0 +1,31 @@
+$(function(){
+  if(!$('.service-provider-form').length){
+    return;
+  }
+  
+  var toggle_form_fields = function(id_protocol){
+    switch(id_protocol){
+      case 'openid_connect':
+        $('.saml-fields').hide();
+        $('.oidc-fields').show();
+        break;
+      case 'saml':
+        $('.saml-fields').show();
+        $('.oidc-fields').hide();
+        break;
+      default:
+        $('.saml-fields').show();
+        $('.oidc-fields').show();
+    }
+  }
+
+  var id_protocol = function(){
+    return $('input[name="service_provider[identity_protocol]"]:checked').val();    
+  }
+
+  toggle_form_fields(id_protocol());
+  
+  $('input[name="service_provider[identity_protocol]"]').change(function(){
+    toggle_form_fields(id_protocol());
+  })
+});

--- a/app/views/service_providers/_form.html.slim
+++ b/app/views/service_providers/_form.html.slim
@@ -3,26 +3,28 @@
 - if current_user.admin?
   = form.input :approved, as: :radio_buttons
 
-= form.input :identity_protocol, as: :radio_buttons
-
 = form.association :user_group,
   as: :collection_select,
   collection: current_user.scoped_user_groups,
   include_blank: '',
   selected: selected_user_group,
   disabled: !can_edit_user_groups?(current_user)
-
-= form.input :friendly_name
-= form.input :description
-= form.input :issuer
-= form.association :agency
-= form.input :logo
-= form.input :acs_url
-= form.input :assertion_consumer_logout_service_url
-= form.input :sp_initiated_login_url
-= form.input :block_encryption, as: :radio_buttons
-= form.input :saml_client_cert
-= form.input :return_to_sp_url
+.common-fields
+  = form.input :friendly_name
+  = form.input :description
+  = form.input :issuer
+  = form.association :agency
+  = form.input :logo
+  = form.input :block_encryption, as: :radio_buttons
+  = form.input :saml_client_cert
+= form.input :identity_protocol, as: :radio_buttons
+.saml-fields
+  = form.input :acs_url
+  = form.input :assertion_consumer_logout_service_url
+  = form.input :sp_initiated_login_url
+  = form.input :return_to_sp_url
+.oidc-fields
+  = form.input :redirect_uri
 fieldset.usa-fieldset-inputs.usa-sans
   legend = t('simple_form.labels.service_provider.attribute_bundle')
   ul
@@ -33,5 +35,4 @@ fieldset.usa-fieldset-inputs.usa-sans
         = b.check_box
         .ml1.inline-block
           = b.label
-= form.input :redirect_uri
 = form.input :active, as: :radio_buttons

--- a/app/views/service_providers/edit.html.slim
+++ b/app/views/service_providers/edit.html.slim
@@ -2,10 +2,11 @@ h2 = t('headings.service_providers.edit')
 
 = simple_form_for(service_provider, html: { autocomplete: 'off', role: 'form' }) do |form|
   - selected_user_group = @service_provider.user_group_id
-  == render 'form', form: form, selected_user_group: selected_user_group
-  .wrapper.actions
-    .action
-      = form.button :submit, 'Update'
-    .action
-      = link_to t('forms.buttons.cancel'), service_provider_path(service_provider),
-        class: 'usa-button usa-button-outline use-button-secondary', role: :button
+  .service-provider-form
+    == render 'form', form: form, selected_user_group: selected_user_group
+    .wrapper.actions
+      .action
+        = form.button :submit, 'Update'
+      .action
+        = link_to t('forms.buttons.cancel'), service_provider_path(service_provider),
+          class: 'usa-button usa-button-outline use-button-secondary', role: :button

--- a/app/views/service_providers/new.html.slim
+++ b/app/views/service_providers/new.html.slim
@@ -6,5 +6,6 @@ p = t('links.attr_description_html',
 
 = simple_form_for(@service_provider, html: { autocomplete: 'off', role: 'form' }) do |form|
   - selected_user_group = current_user.user_group_id
-  == render 'form', form: form, selected_user_group: selected_user_group
-  = form.button :submit, 'Create'
+  .service-provider-form
+    == render 'form', form: form, selected_user_group: selected_user_group
+    = form.button :submit, 'Create'

--- a/spec/features/service_providers_spec.rb
+++ b/spec/features/service_providers_spec.rb
@@ -40,6 +40,34 @@ feature 'Service Providers CRUD' do
       click_on 'Create'
       expect(page).to have_content(ug.name)
     end
+
+    scenario 'saml fields are shown when saml is selected', :js do
+      user = create(:user)
+      login_as(user)
+
+      visit new_service_provider_path
+      choose 'Saml'
+      saml_attributes =
+        %w(acs_url assertion_consumer_logout_service_url sp_initiated_login_url return_to_sp_url)
+      saml_attributes.each do |atr|
+        expect(page).to have_content(t("simple_form.labels.service_provider.#{atr}"))
+      end
+      expect(page).to_not have_content(t('simple_form.labels.service_provider.redirect_uri'))
+    end
+
+    scenario 'oidc fields are shown when oidc is selected', :js do
+      user = create(:user)
+      login_as(user)
+
+      visit new_service_provider_path
+      choose 'Openid connect'
+      saml_attributes =
+        %w(acs_url assertion_consumer_logout_service_url sp_initiated_login_url return_to_sp_url)
+      saml_attributes.each do |atr|
+        expect(page).to_not have_content(t("simple_form.labels.service_provider.#{atr}"))
+      end
+      expect(page).to have_content(t('simple_form.labels.service_provider.redirect_uri'))
+    end
   end
 
   context 'admin user' do


### PR DESCRIPTION
**Why**
Users were filling out unneccessary fields when creating sp's
This eliminates confusion by hiding those fields