### PR TITLE
Automatically publish service providers upon save or update

### DIFF
--- a/app/assets/stylesheets/components/_alert.scss
+++ b/app/assets/stylesheets/components/_alert.scss
@@ -22,6 +22,10 @@ $ico-offset: -10px;
     top: $ico-offset;
     width: $ico-size;
   }
+
+  + .alert {
+    margin-top: - $space-3;
+  }
 }
 
 .alert-notice,

--- a/app/controllers/api/service_providers_controller.rb
+++ b/app/controllers/api/service_providers_controller.rb
@@ -7,7 +7,7 @@ module Api
     end
 
     def update
-      if ServiceProviderUpdater.new.ping
+      if ServiceProviderUpdater.ping
         flash[:notice] = I18n.t('notices.service_providers_refreshed')
       else
         flash[:error] = I18n.t('notices.service_providers_refresh_failed')

--- a/app/controllers/service_providers_controller.rb
+++ b/app/controllers/service_providers_controller.rb
@@ -59,7 +59,16 @@ class ServiceProvidersController < AuthenticatedController
     service_provider.save!
     flash[:success] = I18n.t('notices.service_provider_saved', issuer: service_provider.issuer)
     notify_users(service_provider, initial_action)
+    publish_service_providers
     redirect_to service_provider_path(service_provider)
+  end
+
+  def publish_service_providers
+    if ServiceProviderUpdater.ping
+      flash[:notice] = I18n.t('notices.service_providers_refreshed')
+    else
+      flash[:error] = I18n.t('notices.service_providers_refresh_failed')
+    end
   end
 
   def notify_users(service_provider, initial_action)

--- a/app/services/service_provider_updater.rb
+++ b/app/services/service_provider_updater.rb
@@ -1,16 +1,16 @@
 class ServiceProviderUpdater
-  def ping
+  def self.ping
     resp = HTTParty.post(idp_url, headers: token_header)
     resp.code == 200
   end
 
-  private
+  class <<self
+    def idp_url
+      Figaro.env.idp_sp_url
+    end
 
-  def idp_url
-    Figaro.env.idp_sp_url
-  end
-
-  def token_header
-    { 'X-LOGIN-DASHBOARD-TOKEN' => Figaro.env.dashboard_api_token }
+    def token_header
+      { 'X-LOGIN-DASHBOARD-TOKEN' => Figaro.env.dashboard_api_token }
+    end
   end
 end

--- a/app/views/service_providers/index.html.slim
+++ b/app/views/service_providers/index.html.slim
@@ -1,9 +1,10 @@
 h2 = t('headings.service_providers.main')
 
 .wrapper.actions
-  p.action
-    = button_to t('forms.buttons.trigger_idp_refresh'), api_service_providers_path,
-      class: 'btn btn-link h4 p0 blue regular border-box center', method: :post
+  - if current_user.admin?
+    p.action
+      = button_to t('forms.buttons.trigger_idp_refresh'), api_service_providers_path,
+        class: 'btn btn-link h4 p0 blue regular border-box center', method: :post
   .action
     = link_to t('forms.buttons.create_service_provider'), new_service_provider_path
 

--- a/spec/features/service_providers_spec.rb
+++ b/spec/features/service_providers_spec.rb
@@ -20,6 +20,7 @@ feature 'Service Providers CRUD' do
       click_on 'Create'
 
       expect(page).to have_content('Success')
+      expect(page).to have_content(I18n.t('notices.service_providers_refreshed'))
       within('table.horizontal-headers') do
         expect(page).to have_content('test service_provider')
         expect(page).to have_content('email')
@@ -90,6 +91,16 @@ feature 'Service Providers CRUD' do
 
       expect(page).to have_content('Success')
     end
+
+    scenario 'can publish service providers' do
+      admin = create(:admin)
+      login_as(admin)
+
+      visit service_providers_path
+
+      click_on t('forms.buttons.trigger_idp_refresh')
+      expect(page).to have_content(I18n.t('notices.service_providers_refreshed'))
+    end
   end
 
   context 'Update' do
@@ -109,6 +120,7 @@ feature 'Service Providers CRUD' do
       click_on 'Update'
 
       expect(page).to have_content('Success')
+      expect(page).to have_content(I18n.t('notices.service_providers_refreshed'))
       within('table.horizontal-headers') do
         expect(page).to have_content('app description foobar')
         expect(page).to have_content('change service_provider name')

--- a/spec/services/service_provider_updater_spec.rb
+++ b/spec/services/service_provider_updater_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe ServiceProviderUpdater do
   describe '#ping' do
     it 'returns true for success' do
-      expect(subject.ping).to eq true
+      expect(ServiceProviderUpdater.ping).to eq true
     end
   end
 end


### PR DESCRIPTION
**Why**
Streamlines the process and eliminates an uneccesary extra step