### PR TITLE
Changed documentation link on SP form to open in a new tab

### DIFF
--- a/app/views/service_providers/_form.html.slim
+++ b/app/views/service_providers/_form.html.slim
@@ -1,3 +1,7 @@
+p = t('links.attr_description_html',
+    href: link_to(t('links.attr_description_href'),
+    'https://developers.login.gov/register/', target: :_blank))
+
 = form.error_notification
 
 - if current_user.admin?

--- a/app/views/service_providers/new.html.slim
+++ b/app/views/service_providers/new.html.slim
@@ -1,9 +1,5 @@
 h2 = t('headings.service_providers.new')
 
-p = t('links.attr_description_html',
-    href: link_to(t('links.attr_description_href'),
-    'https://pages.18f.gov/identity-dev-docs'))
-
 = simple_form_for(@service_provider, html: { autocomplete: 'off', role: 'form' }) do |form|
   - selected_user_group = current_user.user_group_id
   .service-provider-form


### PR DESCRIPTION
**Why**
Users who clicked the documentation link
would be directed away from the form

Also added documentation link to the form partial.
Link shows on edit and new forms now.