### PR TITLE
Support multiple redirect_uri values

### DIFF
--- a/app/controllers/service_providers_controller.rb
+++ b/app/controllers/service_providers_controller.rb
@@ -107,13 +107,13 @@ class ServiceProvidersController < AuthenticatedController
       :issuer,
       :logo,
       :metadata_url,
-      :redirect_uri,
       :return_to_sp_url,
       :saml_client_cert,
       :sp_initiated_login_url,
       :user_group_id,
       :identity_protocol,
       attribute_bundle: [],
+      redirect_uris: [],
     )
   end
   # rubocop:enable MethodLength

--- a/app/inputs/json_input.rb
+++ b/app/inputs/json_input.rb
@@ -1,0 +1,17 @@
+# Patch SimpleForm to work for JSON arrays
+class JsonInput < SimpleForm::Inputs::Base
+  def input(wrapper_options)
+    merged_input_options = merge_wrapper_options(
+      input_html_options, wrapper_options.merge(multiple: true)
+    )
+
+    values = object.public_send(attribute_name) || []
+    values << [nil]
+
+    fields = values.map do |value|
+      @builder.text_field(attribute_name, merged_input_options.merge(value: value))
+    end
+
+    safe_join fields
+  end
+end

--- a/app/serializers/service_provider_serializer.rb
+++ b/app/serializers/service_provider_serializer.rb
@@ -11,6 +11,7 @@ class ServiceProviderSerializer < ActiveModel::Serializer
     :issuer,
     :logo,
     :redirect_uri,
+    :redirect_uris,
     :return_to_sp_url,
     :signature,
     :sp_initiated_login_url,
@@ -31,6 +32,10 @@ class ServiceProviderSerializer < ActiveModel::Serializer
 
   def signature
     Digest::SHA256.hexdigest unique_identifier
+  end
+
+  def redirect_uri
+    (object.redirect_uris || []).first
   end
 
   private

--- a/app/views/service_providers/_form.html.slim
+++ b/app/views/service_providers/_form.html.slim
@@ -28,7 +28,7 @@ p = t('links.attr_description_html',
   = form.input :sp_initiated_login_url
   = form.input :return_to_sp_url
 .oidc-fields
-  = form.input :redirect_uri
+  = form.input :redirect_uris
 fieldset.usa-fieldset-inputs.usa-sans
   legend = t('simple_form.labels.service_provider.attribute_bundle')
   ul

--- a/app/views/service_providers/show.html.slim
+++ b/app/views/service_providers/show.html.slim
@@ -53,8 +53,8 @@ table.horizontal-headers
     th = t('simple_form.labels.service_provider.attribute_bundle')
     td.attribute_bundle = (service_provider.attribute_bundle || []).sort.join(', ')
   tr
-    th = t('simple_form.labels.service_provider.redirect_uri')
-    td.attribute_bundle = service_provider.redirect_uri
+    th = t('simple_form.labels.service_provider.redirect_uris')
+    td.attribute_bundle = (service_provider.redirect_uris || []).sort.join(' ')
   tr
     th = t('simple_form.labels.service_provider.active')
     td.active_flag = (service_provider.active? ? 'Yes' : 'No')

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -16,7 +16,7 @@ en:
         friendly_name: Friendly name
         issuer: Issuer
         logo: Logo
-        redirect_uri: Redirect URI (for OpenID Connect)
+        redirect_uris: Redirect URIs (for OpenID Connect)
         return_to_sp_url: Return to SP URL
         saml_client_cert: SAML Client Cert (PEM encoded)
         sp_initiated_login_url: SP Initiated Login URL

--- a/db/migrate/20170531194154_add_multiple_redirect_uris.rb
+++ b/db/migrate/20170531194154_add_multiple_redirect_uris.rb
@@ -1,0 +1,15 @@
+class AddMultipleRedirectUris < ActiveRecord::Migration
+  def up
+    add_column :service_providers, :redirect_uris, :json
+
+    execute <<-SQL
+      UPDATE service_providers
+      SET redirect_uris=array_to_json(ARRAY[redirect_uri])
+      WHERE length(redirect_uri) > 0
+    SQL
+  end
+
+  def down
+    remove_column :service_providers, :redirect_uris, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170509155224) do
+ActiveRecord::Schema.define(version: 20170531194154) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,6 +62,7 @@ ActiveRecord::Schema.define(version: 20170509155224) do
     t.integer  "user_group_id"
     t.string   "logo"
     t.integer  "identity_protocol",                     default: 0
+    t.json     "redirect_uris"
   end
 
   add_index "service_providers", ["issuer"], name: "index_service_providers_on_issuer", unique: true, using: :btree

--- a/spec/features/service_providers_spec.rb
+++ b/spec/features/service_providers_spec.rb
@@ -53,7 +53,7 @@ feature 'Service Providers CRUD' do
       saml_attributes.each do |atr|
         expect(page).to have_content(t("simple_form.labels.service_provider.#{atr}"))
       end
-      expect(page).to_not have_content(t('simple_form.labels.service_provider.redirect_uri'))
+      expect(page).to_not have_content(t('simple_form.labels.service_provider.redirect_uris'))
     end
 
     scenario 'oidc fields are shown when oidc is selected', :js do
@@ -67,7 +67,7 @@ feature 'Service Providers CRUD' do
       saml_attributes.each do |atr|
         expect(page).to_not have_content(t("simple_form.labels.service_provider.#{atr}"))
       end
-      expect(page).to have_content(t('simple_form.labels.service_provider.redirect_uri'))
+      expect(page).to have_content(t('simple_form.labels.service_provider.redirect_uris'))
     end
   end
 

--- a/spec/serializers/service_provider_serializer_spec.rb
+++ b/spec/serializers/service_provider_serializer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ServiceProviderSerializer do
   subject(:serializer) { ServiceProviderSerializer.new(service_provider) }
   let(:service_provider) do
     build(:service_provider,
-          redirect_uri: 'http://localhost:9292/result',
+          redirect_uris: ['http://localhost:9292/result', 'x-example-app:/result'],
           updated_at: Time.zone.now)
   end
 
@@ -14,8 +14,12 @@ RSpec.describe ServiceProviderSerializer do
     it 'serializes attributes' do
       aggregate_failures do
         expect(as_json[:issuer]).to eq(service_provider.issuer)
-        expect(as_json[:redirect_uri]).to eq(service_provider.redirect_uri)
+        expect(as_json[:redirect_uris]).to eq(service_provider.redirect_uris)
       end
+    end
+
+    it 'is backwards compatible with (singular) redirect_uri' do
+      expect(as_json[:redirect_uri]).to eq(service_provider.redirect_uris.first)
     end
   end
 end


### PR DESCRIPTION
**Why**: Better OIDC support

First step of multiple, eventually will follow up with a PR to drop the old column once we have everything running off the new column