### PR TITLE
Remove foreman from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem 'devise'
 gem 'dotenv-rails'
 gem 'enum_help'
 gem 'figaro'
-gem 'foreman', require: false
 gem 'httparty'
 gem 'jquery-rails'
 gem 'newrelic_rpm', '>= 3.9.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,8 +131,7 @@ GEM
       factory_girl (~> 4.8.0)
       railties (>= 3.0.0)
     figaro (1.1.1)
-      thor (~> 0.19.1)
-    foreman (0.83.0)
+      thor (~> 0.14)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     hashdiff (0.3.2)
@@ -395,7 +394,6 @@ DEPENDENCIES
   enum_help
   factory_girl_rails
   figaro
-  foreman
   httparty
   i18n-tasks
   jquery-rails
@@ -433,4 +431,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.14.6
+   1.15.0


### PR DESCRIPTION
__Why__

* The older version is causing builds to fail.

```
Downloading foreman-0.83.0 revealed dependencies not in the API or the lockfile (thor (~> 0.19.1)).
Either installing with `--full-index` or running `bundle update foreman` should fix the problem.
```

__How__

* Update foreman as the error message suggests.