### PR TITLE
Downgrades bummr gem to 0.1.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ group :deploy do
 end
 
 group :development do
-  gem 'bummr', require: false
+  gem 'bummr', '0.1.8', require: false
   gem 'quiet_assets'
   gem 'rubocop'
   gem 'slim_lint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,7 @@ GEM
     bullet (5.5.1)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.10.0)
-    bummr (0.2.0)
+    bummr (0.1.8)
       rainbow
       thor
     capistrano (3.8.1)
@@ -386,7 +386,7 @@ DEPENDENCIES
   actionmailer-text
   active_model_serializers
   bullet
-  bummr
+  bummr (= 0.1.8)
   capistrano
   capistrano-passenger
   capistrano-rails


### PR DESCRIPTION
#### Why
Version 0.2.0 has been **yanked** 🔪 
https://rubygems.org/gems/bummr/versions/0.2.0

#### How
Pins bummr gem version to 0.1.8