### PR TITLE
Remove unused Mailcatcher gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,6 @@ group :development, :test do
   gem 'bullet'
   gem 'factory_girl_rails'
   gem 'i18n-tasks'
-  gem 'mailcatcher', '0.6.3'
   gem 'pry'
   gem 'rspec-rails', '~> 3.4.0'
   gem 'saml_idp', git: 'https://github.com/18F/saml_idp.git', branch: 'master'
@@ -57,6 +56,7 @@ group :test do
   gem 'poltergeist'
   gem 'rack_session_access'
   gem 'shoulda-matchers'
+  gem 'sinatra'
   gem 'timecop'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,7 +99,6 @@ GEM
     concurrent-ruby (1.0.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    daemons (1.2.4)
     database_cleaner (1.6.1)
     debug_inspector (0.0.2)
     delayed_job (4.1.3)
@@ -126,7 +125,6 @@ GEM
     enum_help (0.0.17)
       activesupport (>= 3.0.0)
     erubis (2.7.0)
-    eventmachine (1.0.9.1)
     execjs (2.7.0)
     factory_girl (4.8.0)
       activesupport (>= 3.0.0)
@@ -166,14 +164,6 @@ GEM
       systemu (~> 2.6.2)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
-    mailcatcher (0.6.3)
-      activesupport (>= 4.0.0, < 5)
-      eventmachine (= 1.0.9.1)
-      mail (~> 2.3)
-      sinatra (~> 1.2)
-      skinny (~> 0.2.3)
-      sqlite3 (~> 1.3)
-      thin (~> 1.5.0)
     method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
@@ -309,13 +299,10 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
-    sinatra (1.4.7)
+    sinatra (1.4.8)
       rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
-    skinny (0.2.4)
-      eventmachine (~> 1.0.0)
-      thin (>= 1.5, < 1.7)
     slim (3.0.8)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 1.3.3, < 2.1)
@@ -336,7 +323,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.12)
     sshkit (1.13.1)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
@@ -345,10 +331,6 @@ GEM
     temple (0.8.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    thin (1.5.1)
-      daemons (>= 1.0.9)
-      eventmachine (>= 0.12.6)
-      rack (>= 1.0.0)
     thor (0.19.4)
     thread (0.2.2)
     thread_safe (0.3.6)
@@ -402,7 +384,6 @@ DEPENDENCIES
   httparty
   i18n-tasks
   jquery-rails
-  mailcatcher (= 0.6.3)
   newrelic_rpm (>= 3.9.8)
   nokogiri (>= 1.7.1)
   omniauth-saml
@@ -425,6 +406,7 @@ DEPENDENCIES
   secure_headers (~> 3.0.0)
   shoulda-matchers
   simple_form
+  sinatra
   slim-rails
   slim_lint
   timecop
@@ -436,4 +418,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.15.0
+   1.15.4

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,2 @@
 web: bundle exec rackup config.ru --port ${PORT:-3000}
 worker: bundle exec rake jobs:work
-mail: bundle exec mailcatcher -f --smtp-port 2025 --http-port 2080


### PR DESCRIPTION
**Why**: It looks like this was copied and pasted from the IdP code.
The dashboard app uses the IdP app for logins and account creation.
It doesn't send emails itself, so there's no need for Mailcatcher.