### PR TITLE
Cleanup: remove old singular redirect_uri column

### DIFF
--- a/app/serializers/service_provider_serializer.rb
+++ b/app/serializers/service_provider_serializer.rb
@@ -10,7 +10,6 @@ class ServiceProviderSerializer < ActiveModel::Serializer
     :friendly_name,
     :issuer,
     :logo,
-    :redirect_uri,
     :redirect_uris,
     :return_to_sp_url,
     :signature,
@@ -32,10 +31,6 @@ class ServiceProviderSerializer < ActiveModel::Serializer
 
   def signature
     Digest::SHA256.hexdigest unique_identifier
-  end
-
-  def redirect_uri
-    (object.redirect_uris || []).first
   end
 
   private

--- a/db/migrate/20171016184947_drop_redirect_uri_from_service_providers.rb
+++ b/db/migrate/20171016184947_drop_redirect_uri_from_service_providers.rb
@@ -1,0 +1,5 @@
+class DropRedirectUriFromServiceProviders < ActiveRecord::Migration
+  def change
+    remove_column :service_providers, :redirect_uri, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170623192352) do
+ActiveRecord::Schema.define(version: 20171016184947) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -67,7 +67,6 @@ ActiveRecord::Schema.define(version: 20170623192352) do
     t.text     "return_to_sp_url"
     t.integer  "agency_id",                                             null: false
     t.json     "attribute_bundle"
-    t.string   "redirect_uri"
     t.integer  "group_id"
     t.string   "logo"
     t.integer  "identity_protocol",                     default: 0

--- a/spec/serializers/service_provider_serializer_spec.rb
+++ b/spec/serializers/service_provider_serializer_spec.rb
@@ -17,9 +17,5 @@ RSpec.describe ServiceProviderSerializer do
         expect(as_json[:redirect_uris]).to eq(service_provider.redirect_uris)
       end
     end
-
-    it 'is backwards compatible with (singular) redirect_uri' do
-      expect(as_json[:redirect_uri]).to eq(service_provider.redirect_uris.first)
-    end
   end
 end


### PR DESCRIPTION
**Why**: We have fully migrated to the plural redirect_uris column