### PR TITLE
Validate that SP redirect uris are parsable uris

### DIFF
--- a/spec/features/service_providers_spec.rb
+++ b/spec/features/service_providers_spec.rb
@@ -32,6 +32,33 @@ feature 'Service Providers CRUD' do
       end
     end
 
+    scenario 'can update service provider with multiple redirect uris' do
+      user = create(:user)
+      service_provider = create(:service_provider, user: user)
+      login_as(user)
+
+      visit edit_service_provider_path(service_provider)
+      fill_in 'service_provider_redirect_uris', with: 'https://foo.com'
+      click_on 'Update'
+
+      service_provider.reload
+      expect(service_provider.redirect_uris).to eq(['https://foo.com'])
+
+      visit edit_service_provider_path(service_provider)
+      page.all('[name="service_provider[redirect_uris][]"]')[1].set 'https://bar.com'
+      click_on 'Update'
+
+      service_provider.reload
+      expect(service_provider.redirect_uris).to eq(['https://foo.com', 'https://bar.com'])
+
+      visit edit_service_provider_path(service_provider)
+      page.all('[name="service_provider[redirect_uris][]"]')[0].set ''
+      click_on 'Update'
+
+      service_provider.reload
+      expect(service_provider.redirect_uris).to eq(['https://bar.com'])
+    end
+
     scenario 'saml fields are shown when saml is selected', :js do
       user = create(:user)
       login_as(user)

--- a/spec/models/service_provider_spec.rb
+++ b/spec/models/service_provider_spec.rb
@@ -38,6 +38,23 @@ describe ServiceProvider do
 
       expect(service_provider.valid?).to eq(true)
     end
+
+    it 'validates that all redirect_uris are absolute, parsable uris' do
+      valid_sp = build(:service_provider, redirect_uris: ['http://foo.com'])
+      missing_protocol_sp = build(:service_provider, redirect_uris: ['foo.com'])
+      relative_uri_sp = build(:service_provider, redirect_uris: ['/asdf/hjkl'])
+      bad_uri_sp = build(:service_provider, redirect_uris: [' http://foo.com'])
+
+      expect(valid_sp).to be_valid
+      expect(missing_protocol_sp).to_not be_valid
+      expect(relative_uri_sp).to_not be_valid
+      expect(bad_uri_sp).to_not be_valid
+    end
+
+    it 'allows redirect_uris to be empty' do
+      sp = build(:service_provider, redirect_uris: [])
+      expect(sp).to be_valid
+    end
   end
 
   let(:service_provider) { build(:service_provider) }
@@ -108,6 +125,14 @@ describe ServiceProvider do
       service_provider.approved = true
       service_provider.save!
       expect(service_provider.recently_approved?).to eq true
+    end
+  end
+
+  describe '#service_provider=' do
+    it 'should filter out nil and empty strings' do
+      service_provider.redirect_uris = ['https://foo.com', nil, 'http://bar.com', '']
+
+      expect(service_provider.redirect_uris).to eq(['https://foo.com', 'http://bar.com'])
     end
   end
 end


### PR DESCRIPTION
**Why**: We added this validation to the IDP. This means that we need a
corresponding validation on the dashboard since the IDP reads redirect
URIs from the dashboard

This change also includes some code to change the process for adding
multiple URIs so that empty strings don't get added.