### PR TITLE
Add ACS url to SAML config

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -9,6 +9,7 @@ test: &default
   saml_idp_slo_url: 'http://idp.example.com/saml/logout'
   saml_idp_sso_url: 'http://idp.example.com/saml/auth'
   saml_name_id_format: 'urn:oasis:names:tc:SAML:1.1:nameid-format:persistent'
+  saml_sp_acs_url: 'http://idp.example.com/users/auth/saml/callback'
   saml_sp_certificate: |
     -----BEGIN CERTIFICATE-----
     MIIFLjCCAxYCCQD/dXjTvpnD0jANBgkqhkiG9w0BAQsFADBZMQswCQYDVQQGEwJV
@@ -46,7 +47,7 @@ test: &default
     -----BEGIN RSA PRIVATE KEY-----
     Proc-Type: 4,ENCRYPTED
     DEK-Info: DES-EDE3-CBC,3BBA2AE203104123
-    
+
     OP57tGYQbWtS7uQaTLRjqp+ZvuSp3eOYqHiakpGh/aLZfOrs751y0Qj51b/QXEdV
     YSRsg7xdm7MIttiYMln23JAU8gBiUGFfDzMC65I+WLDSiHFBVQ7s8aJoU9o4li08
     1/37pQ3Z2aZ0k4oPKr3iQuilFeCdJ8yFJlZ070SRGyI/8ui2T2UPDmVenF8ZTLJ8
@@ -111,6 +112,7 @@ development:
   saml_idp_fingerprint: '8B:D5:C2:E8:9A:2B:CE:B7:4B:95:50:BA:16:79:05:27:17:D1:D3:67'
   saml_idp_slo_url: 'http://localhost:3000/api/saml/logout'
   saml_idp_sso_url: 'http://localhost:3000/api/saml/auth'
+  saml_sp_acs_url: 'http://localhost:3001/users/auth/saml/callback'
 
 production:
   <<: *default

--- a/lib/saml_config.rb
+++ b/lib/saml_config.rb
@@ -5,12 +5,13 @@ module Saml
     # rubocop:disable AbcSize, MethodLength
     def self.build_settings
       Hashie::Mash.new(
-        issuer:                     Figaro.env.saml_sp_issuer,
-        idp_sso_target_url:         Figaro.env.saml_idp_sso_url,
-        idp_slo_target_url:         Figaro.env.saml_idp_slo_url,
-        idp_cert_fingerprint:       Figaro.env.saml_idp_fingerprint,
-        name_identifier_format:     Figaro.env.saml_name_id_format,
-        certificate:                Figaro.env.saml_sp_certificate,
+        issuer:                         Figaro.env.saml_sp_issuer,
+        assertion_consumer_service_url: Figaro.env.saml_sp_acs_url,
+        idp_sso_target_url:             Figaro.env.saml_idp_sso_url,
+        idp_slo_target_url:             Figaro.env.saml_idp_slo_url,
+        idp_cert_fingerprint:           Figaro.env.saml_idp_fingerprint,
+        name_identifier_format:         Figaro.env.saml_name_id_format,
+        certificate:                    Figaro.env.saml_sp_certificate,
         private_key: OpenSSL::PKey::RSA.new(
           Figaro.env.saml_sp_private_key,
           Figaro.env.saml_sp_private_key_password,


### PR DESCRIPTION
**Why**: So that we can be certain we're comparing against the correct
ACS url when validating the SAML subject confirmation.