### PR TITLE
Increase the timeout length

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -158,7 +158,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  config.timeout_in = 30.minutes
+  config.timeout_in = 8.hours
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.


### PR DESCRIPTION
**Why**: Currently, the timeout is 30 min, which is too short for our
agency developer workflows. This increases to 8 hours, so that a
developer should only have to log in to the dashboard once per day.