### PR TITLE
Update tests for removed SP `agency` attribute

### DIFF
--- a/spec/factories/service_providers.rb
+++ b/spec/factories/service_providers.rb
@@ -4,6 +4,5 @@ FactoryGirl.define do
     sequence(:issuer) { |n| "urn:gov:gsa:SAML:2.0.profiles:sp:sso:DEPT:APP-#{n}" }
     sequence(:description) { |n| "test service_provider description #{n}" }
     association :user, factory: :user
-    association :agency, factory: :agency
   end
 end

--- a/spec/requests/service_provider_api_spec.rb
+++ b/spec/requests/service_provider_api_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe 'Service Provider API' do
+  it 'returns JSON' do
+    app = create(:service_provider)
+    get '/api/service_providers'
+    json = JSON.parse(response.body)
+    expect(response).to be_success
+    expect(json[0]["issuer"]).to eq(app.issuer)
+  end
+end


### PR DESCRIPTION
**Why**: We removed the SP `agency` field from the views, since it isn't particularly useful for testing. This removes the agencies associated in the SP factory and adds a test to ensure JSON is flowing from the `/api/service_providers` endpoint.