### PR TITLE
Remove worker process, as Delayed::Job is no longer used

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,1 @@
 web: bundle exec rackup config.ru --port ${PORT:-3000}
-worker: bundle exec rake jobs:work


### PR DESCRIPTION
As part of #167, remove the worker process, as the DJ tasks no longer exist.

Tested that `make run` works locally now, and there are no spec failures.