### PR TITLE
Add piv/cac attributes for OIDC

### DIFF
--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -40,7 +40,7 @@ class ServiceProvider < ApplicationRecord
 
   # rubocop:disable MethodLength
   def self.possible_attributes
-    possible = %w(
+    possible = %w[
       email
       first_name
       middle_name
@@ -53,7 +53,9 @@ class ServiceProvider < ApplicationRecord
       dob
       ssn
       phone
-    )
+      x509_subject
+      x509_presented
+    ]
     Hash[*possible.collect { |v| [v, v] }.flatten]
   end
   # rubocop:ensable MethodLength


### PR DESCRIPTION
**Why**:
We want to share the subject of the piv/cac certificate
with SPs that have a need to know.

**How**:
We add attributes for the subject and presence of the
piv/cac during the login session.