### PR TITLE
Specify Rails version in migrations

### DIFF
--- a/db/migrate/20160509195741_add_users_and_applications.rb
+++ b/db/migrate/20160509195741_add_users_and_applications.rb
@@ -1,4 +1,4 @@
-class AddUsersAndApplications < ActiveRecord::Migration
+class AddUsersAndApplications < ActiveRecord::Migration[4.2]
   def change
     create_table :users do |tbl|
       tbl.uuid :uuid, null: false

--- a/db/migrate/20160509214815_create_delayed_jobs.rb
+++ b/db/migrate/20160509214815_create_delayed_jobs.rb
@@ -1,4 +1,4 @@
-class CreateDelayedJobs < ActiveRecord::Migration
+class CreateDelayedJobs < ActiveRecord::Migration[4.2]
   def self.up
     create_table :delayed_jobs, force: true do |table|
       table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue

--- a/db/migrate/20160509215026_add_devise_to_users.rb
+++ b/db/migrate/20160509215026_add_devise_to_users.rb
@@ -1,4 +1,4 @@
-class AddDeviseToUsers < ActiveRecord::Migration
+class AddDeviseToUsers < ActiveRecord::Migration[4.2]
   def self.up
     change_table :users do |t|
       ## Trackable

--- a/db/migrate/20160516150051_add_active_flag_to_applications.rb
+++ b/db/migrate/20160516150051_add_active_flag_to_applications.rb
@@ -1,4 +1,4 @@
-class AddActiveFlagToApplications < ActiveRecord::Migration
+class AddActiveFlagToApplications < ActiveRecord::Migration[4.2]
   def change
     add_column :applications, :active, :boolean, null: false, default: false
   end

--- a/db/migrate/20160517142052_add_admin_user_flag.rb
+++ b/db/migrate/20160517142052_add_admin_user_flag.rb
@@ -1,4 +1,4 @@
-class AddAdminUserFlag < ActiveRecord::Migration
+class AddAdminUserFlag < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :admin, :boolean, null: false, default: false
   end

--- a/db/migrate/20160517142216_add_application_approved_flag.rb
+++ b/db/migrate/20160517142216_add_application_approved_flag.rb
@@ -1,4 +1,4 @@
-class AddApplicationApprovedFlag < ActiveRecord::Migration
+class AddApplicationApprovedFlag < ActiveRecord::Migration[4.2]
   def change
     add_column :applications, :approved, :boolean, null: false, default: false
   end

--- a/db/migrate/20160711194816_rename_applications.rb
+++ b/db/migrate/20160711194816_rename_applications.rb
@@ -1,4 +1,4 @@
-class RenameApplications < ActiveRecord::Migration
+class RenameApplications < ActiveRecord::Migration[4.2]
   def change
     rename_table :applications, :service_providers
   end

--- a/db/migrate/20160715161608_uui_dto_string.rb
+++ b/db/migrate/20160715161608_uui_dto_string.rb
@@ -1,4 +1,4 @@
-class UuiDtoString < ActiveRecord::Migration
+class UuiDtoString < ActiveRecord::Migration[4.2]
   def change
     change_column :users, :uuid, :string, null: false
   end

--- a/db/migrate/20170112194141_change_name_to_friendly_name.rb
+++ b/db/migrate/20170112194141_change_name_to_friendly_name.rb
@@ -1,4 +1,4 @@
-class ChangeNameToFriendlyName < ActiveRecord::Migration
+class ChangeNameToFriendlyName < ActiveRecord::Migration[4.2]
   def change
     rename_column :service_providers, :name, :friendly_name
   end

--- a/db/migrate/20170112195642_change_issuer_to_string.rb
+++ b/db/migrate/20170112195642_change_issuer_to_string.rb
@@ -1,4 +1,4 @@
-class ChangeIssuerToString < ActiveRecord::Migration
+class ChangeIssuerToString < ActiveRecord::Migration[4.2]
   def change
     change_column :service_providers, :issuer, :string, null: false
   end

--- a/db/migrate/20170113162235_add_sp_attributes.rb
+++ b/db/migrate/20170113162235_add_sp_attributes.rb
@@ -1,4 +1,4 @@
-class AddSpAttributes < ActiveRecord::Migration
+class AddSpAttributes < ActiveRecord::Migration[4.2]
   def change
     add_column :service_providers, :agency, :string
     add_column :service_providers, :sp_initiated_login_url, :text

--- a/db/migrate/20170117193214_add_agency_model.rb
+++ b/db/migrate/20170117193214_add_agency_model.rb
@@ -1,4 +1,4 @@
-class AddAgencyModel < ActiveRecord::Migration
+class AddAgencyModel < ActiveRecord::Migration[4.2]
   def change
     create_table :agencies do |t|
       t.string :name, null: false

--- a/db/migrate/20170117193703_move_agency_name.rb
+++ b/db/migrate/20170117193703_move_agency_name.rb
@@ -1,4 +1,4 @@
-class MoveAgencyName < ActiveRecord::Migration
+class MoveAgencyName < ActiveRecord::Migration[4.2]
   class ServiceProvider < ActiveRecord::Base
   end
 

--- a/db/migrate/20170117222117_add_attribute_bundle.rb
+++ b/db/migrate/20170117222117_add_attribute_bundle.rb
@@ -1,4 +1,4 @@
-class AddAttributeBundle < ActiveRecord::Migration
+class AddAttributeBundle < ActiveRecord::Migration[4.2]
   def change
     add_column :service_providers, :attribute_bundle, :json
   end

--- a/db/migrate/20170209190458_add_redirect_uri_to_service_providers.rb
+++ b/db/migrate/20170209190458_add_redirect_uri_to_service_providers.rb
@@ -1,4 +1,4 @@
-class AddRedirectUriToServiceProviders < ActiveRecord::Migration
+class AddRedirectUriToServiceProviders < ActiveRecord::Migration[4.2]
   def change
     add_column :service_providers, :redirect_uri, :string
   end

--- a/db/migrate/20170301184735_create_organizations.rb
+++ b/db/migrate/20170301184735_create_organizations.rb
@@ -1,4 +1,4 @@
-class CreateOrganizations < ActiveRecord::Migration
+class CreateOrganizations < ActiveRecord::Migration[4.2]
   def change
     create_table :organizations do |t|
       t.timestamps null: false

--- a/db/migrate/20170302011548_organization_has_many_service_providers.rb
+++ b/db/migrate/20170302011548_organization_has_many_service_providers.rb
@@ -1,4 +1,4 @@
-class OrganizationHasManyServiceProviders < ActiveRecord::Migration
+class OrganizationHasManyServiceProviders < ActiveRecord::Migration[4.2]
   def change
     add_reference :service_providers, :organization, index: true, foreign_key: true
   end

--- a/db/migrate/20170303182534_rename_organizations_to_user_groups.rb
+++ b/db/migrate/20170303182534_rename_organizations_to_user_groups.rb
@@ -1,4 +1,4 @@
-class RenameOrganizationsToUserGroups < ActiveRecord::Migration
+class RenameOrganizationsToUserGroups < ActiveRecord::Migration[4.2]
   def up
     rename_column :organizations, :team_name, :name
     add_index :organizations, :name, unique: true

--- a/db/migrate/20170307195917_user_group_has_many_users.rb
+++ b/db/migrate/20170307195917_user_group_has_many_users.rb
@@ -1,4 +1,4 @@
-class UserGroupHasManyUsers < ActiveRecord::Migration
+class UserGroupHasManyUsers < ActiveRecord::Migration[4.2]
   def change
     add_reference :users, :user_group, index: true
   end

--- a/db/migrate/20170330181317_add_logo_to_service_providers.rb
+++ b/db/migrate/20170330181317_add_logo_to_service_providers.rb
@@ -1,4 +1,4 @@
-class AddLogoToServiceProviders < ActiveRecord::Migration
+class AddLogoToServiceProviders < ActiveRecord::Migration[4.2]
   def change
     add_column :service_providers, :logo, :string
   end

--- a/db/migrate/20170509155224_add_auth_types_to_service_providers.rb
+++ b/db/migrate/20170509155224_add_auth_types_to_service_providers.rb
@@ -1,4 +1,4 @@
-class AddAuthTypesToServiceProviders < ActiveRecord::Migration
+class AddAuthTypesToServiceProviders < ActiveRecord::Migration[4.2]
   def change
     add_column :service_providers, :identity_protocol, :integer, default: 0
   end

--- a/db/migrate/20170522211709_change_user_group_to_groups.rb
+++ b/db/migrate/20170522211709_change_user_group_to_groups.rb
@@ -1,4 +1,4 @@
-class ChangeUserGroupToGroups < ActiveRecord::Migration
+class ChangeUserGroupToGroups < ActiveRecord::Migration[4.2]
   def change
     rename_table :user_groups, :groups
     rename_column :users, :user_group_id, :group_id

--- a/db/migrate/20170523193129_add_users_groups_table.rb
+++ b/db/migrate/20170523193129_add_users_groups_table.rb
@@ -1,4 +1,4 @@
-class AddUsersGroupsTable < ActiveRecord::Migration
+class AddUsersGroupsTable < ActiveRecord::Migration[4.2]
   def change
     create_table :groups_users, id: false do |t|
       t.belongs_to :user, index: true

--- a/db/migrate/20170531194154_add_multiple_redirect_uris.rb
+++ b/db/migrate/20170531194154_add_multiple_redirect_uris.rb
@@ -1,4 +1,4 @@
-class AddMultipleRedirectUris < ActiveRecord::Migration
+class AddMultipleRedirectUris < ActiveRecord::Migration[4.2]
   def up
     add_column :service_providers, :redirect_uris, :json
 

--- a/db/migrate/20170605175127_create_user_groups.rb
+++ b/db/migrate/20170605175127_create_user_groups.rb
@@ -1,4 +1,4 @@
-class CreateUserGroups < ActiveRecord::Migration
+class CreateUserGroups < ActiveRecord::Migration[4.2]
   def change
     create_table :user_groups do |t|
       t.belongs_to :user, index: true

--- a/db/migrate/20170615204004_drop_groups_user.rb
+++ b/db/migrate/20170615204004_drop_groups_user.rb
@@ -1,4 +1,4 @@
-class DropGroupsUser < ActiveRecord::Migration
+class DropGroupsUser < ActiveRecord::Migration[4.2]
   def change
     drop_table :groups_users
   end

--- a/db/migrate/20170623192352_move_users_to_new_groups.rb
+++ b/db/migrate/20170623192352_move_users_to_new_groups.rb
@@ -1,10 +1,10 @@
-class MoveUsersToNewGroups < ActiveRecord::Migration
+class MoveUsersToNewGroups < ActiveRecord::Migration[4.2]
   def up
     execute <<-SQL
       INSERT INTO user_groups (user_id, group_id, created_at, updated_at)
       SELECT id, group_id, NOW(), NOW()
       FROM users
-      WHERE group_id IS NOT NULL 
+      WHERE group_id IS NOT NULL
     SQL
   end
 end

--- a/db/migrate/20171016184947_drop_redirect_uri_from_service_providers.rb
+++ b/db/migrate/20171016184947_drop_redirect_uri_from_service_providers.rb
@@ -1,4 +1,4 @@
-class DropRedirectUriFromServiceProviders < ActiveRecord::Migration
+class DropRedirectUriFromServiceProviders < ActiveRecord::Migration[4.2]
   def change
     remove_column :service_providers, :redirect_uri, :string
   end

--- a/db/migrate/20180302220332_remove_user_uuid_null_constraint.rb
+++ b/db/migrate/20180302220332_remove_user_uuid_null_constraint.rb
@@ -1,4 +1,4 @@
-class RemoveUserUuidNullConstraint < ActiveRecord::Migration
+class RemoveUserUuidNullConstraint < ActiveRecord::Migration[4.2]
   def change
     change_column_null(:users, :uuid, true)
   end

--- a/db/migrate/20180308224634_require_service_provider_friendly_name.rb
+++ b/db/migrate/20180308224634_require_service_provider_friendly_name.rb
@@ -1,4 +1,4 @@
-class RequireServiceProviderFriendlyName < ActiveRecord::Migration
+class RequireServiceProviderFriendlyName < ActiveRecord::Migration[4.2]
   def change
     change_column_null(:service_providers, :friendly_name, false)
   end

--- a/db/migrate/20180308225011_remove_service_provider_agency_null_constraint.rb
+++ b/db/migrate/20180308225011_remove_service_provider_agency_null_constraint.rb
@@ -1,4 +1,4 @@
-class RemoveServiceProviderAgencyNullConstraint < ActiveRecord::Migration
+class RemoveServiceProviderAgencyNullConstraint < ActiveRecord::Migration[4.2]
   def change
     change_column_null(:service_providers, :agency_id, true)
   end

--- a/db/migrate/20180309002603_service_provider_active_by_default.rb
+++ b/db/migrate/20180309002603_service_provider_active_by_default.rb
@@ -1,4 +1,4 @@
-class ServiceProviderActiveByDefault < ActiveRecord::Migration
+class ServiceProviderActiveByDefault < ActiveRecord::Migration[4.2]
   def change
     change_column_default(:service_providers, :active, true)
   end

--- a/db/migrate/20180309010908_allow_group_description_to_be_empty.rb
+++ b/db/migrate/20180309010908_allow_group_description_to_be_empty.rb
@@ -1,4 +1,4 @@
-class AllowGroupDescriptionToBeEmpty < ActiveRecord::Migration
+class AllowGroupDescriptionToBeEmpty < ActiveRecord::Migration[4.2]
   def change
     change_column_null(:groups, :description, true)
   end


### PR DESCRIPTION
**Why**: Rails 5 requires this when running migrations.
Fixes #174