### PR TITLE
LG-276 Disallow agencies from adding invalid certs into the dashboard

### DIFF
--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -7,3 +7,5 @@ en:
           attributes:
             issuer:
               invalid: is not formatted correctly
+            saml_client_cert:
+              invalid: is not valid

--- a/spec/models/service_provider_spec.rb
+++ b/spec/models/service_provider_spec.rb
@@ -30,6 +30,49 @@ describe ServiceProvider do
       )
     end
 
+    it 'accepts a blank certificate' do
+      sp = build(:service_provider, redirect_uris: [], saml_client_cert: '')
+
+      expect(sp).to be_valid
+    end
+
+    it 'fails if certificate is present but not x509' do
+      sp = build(:service_provider, redirect_uris: [], saml_client_cert: 'foo')
+
+      expect(sp).to_not be_valid
+      expect(sp.errors[:saml_client_cert]).
+        to include(
+          t('activerecord.errors.models.service_provider.attributes.saml_client_cert.invalid')
+        )
+    end
+
+    it 'accepts a valid x509 certificate' do
+      valid_cert = <<~CERT
+      -----BEGIN CERTIFICATE-----
+      MIIDAjCCAeoCCQDnptBMGdfBIjANBgkqhkiG9w0BAQsFADBCMQswCQYDVQQGEwJV
+      UzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHU2VhdHRsZTEMMAoGA1UE
+      ChMDMThGMCAXDTE0MTAwODIzMzkzMVoYDzIxMDYwMTEyMjMzOTMxWjBCMQswCQYD
+      VQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHU2VhdHRsZTEM
+      MAoGA1UEChMDMThGMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1zps
+      ODzA7AHnls/NaICXSuBjyRbmEmDsoAl6YC/3ljBfG8POZre5wTeSjkPaj/h70ai5
+      DEWrG3PyEJ0D6QqwNjReChq3AFSSnPLZeRu11N4UVvScJwCpRMs2LD93BBfFy8VU
+      SQIOsPdrpy9ct31aNzYhi7LF3GBgIwcwq3SLxaF+YYDbbGqHZ8XkjrQlQlRGOPc8
+      dcKcl0azNqSP4jAp83sw2NsKNPgDpI3PCs3H4C2q0RV/V+A4EIXi/3brAmnwKSOA
+      JZ2ZAUIjHkv/Y1kk1TzAcy6s/V5f5Mxb4BjXxdAB18umI+EnfHLupV2fScOYY833
+      AHSpuBiY+b7UfYPU5QIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQCrjv4rCw3Qhpyv
+      konOP/Yufxj/SwkaZdanJCnbOvndRk2qO57FQU9qPwUJOu8kws8Xat+A+4ow2hQl
+      C0b4OlifwrYcnBK/hDOcMOOH/d8na2bzOSg7lkHMOK3luELxPqsnkrszwtqAYs6K
+      cLk2AEacrkAG0DVfOqYOGtUGUrx5QDYutX2kz24VcZ10so4IfRYI4EJX/tF46lqy
+      dp6KaRxeVNQo21CGhfzeBSqgd0tRicu9uHzI57nxCLIzSQoLT5c6geCl5LJ7DxS2
+      kaNiHglqe6GyLbbp3Y5q45xyBGPtJVT6kR6XqK4sEJPRgznbDn2NDx0Ef9mxHdVP
+      e0sZY2CS
+      -----END CERTIFICATE-----
+      CERT
+      sp = build(:service_provider, redirect_uris: [], saml_client_cert: valid_cert)
+
+      expect(sp).to be_valid
+    end
+
     it 'does not validate issuer format on update' do
       service_provider = build(:service_provider, issuer: 'I am invalid :)')
       service_provider.save(validate: false)


### PR DESCRIPTION
**Why**: To streamline agency integration and automate troubleshooting

**How**: Add a model validation to load the certificate with OpenSSL::X509 and return an error if OpenSSL raises an exception