### PR TITLE
Fix grammar typo on app update form

### DIFF
--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -25,7 +25,7 @@
 <%= form.input :return_to_sp_url, input_html: { class: 'h4p4' }, label: "<b>Return to App URL</b><br>The applications URL which login.gov provides to users when they wish to go directly to the app's site or cancel out of authentication. For example: <code>https://app.agency.gov</code>".html_safe %>
 
 <div class="oidc-fields">
-  <%= form.input :redirect_uris, label: "<b>Redirect URIs</b> — <i>OpenID Connect only</i><br>One or more URI login.gov will redirect to after authentication. These can be web URLs (public, internal, or localhost) or a custom scheme to support native applications, for example: <code>x-example-app:/result</code>".html_safe %>
+  <%= form.input :redirect_uris, label: "<b>Redirect URIs</b> — <i>OpenID Connect only</i><br>One or more URIs that login.gov will redirect to after authentication. These can be web URLs (public, internal, or localhost) or a custom scheme to support native applications, for example: <code>x-example-app:/result</code>".html_safe %>
   <button id="add-redirect-uri-field" class="usa-button" type="button">Add another URI</button>
 </div>
 


### PR DESCRIPTION
This pluralizes a word and adds a `that` to make it more clear.