### PR TITLE
Give the contact email directly for non-found users

### DIFF
--- a/app/views/users/none.html.erb
+++ b/app/views/users/none.html.erb
@@ -1,3 +1,3 @@
 <h1>We couldn't find your account 😢</h1>
 
-<p>Contact the login.gov team for help.</p>
+<p>Contact us at <a href="mailto:partners@login.gov">partners@login.gov</a> for help.</p>


### PR DESCRIPTION
We had someone write in about trying to develop against Login and having created an account but not being found, so they saw this error message. They then wrote hello@login.gov to ask about why, and then that help desk directed them to partners@login.gov, which they then emailed.

This helps people in that situation short-circuit that process. Since it's only shown once folks are logged into the dashboard, it seems unlikely to create a significant risk of spam, or of non-developers using it for non-related support questions.