### PR TITLE
LG-838 Admins can indicate which apps are live

### DIFF
--- a/app/controllers/service_providers_controller.rb
+++ b/app/controllers/service_providers_controller.rb
@@ -50,12 +50,9 @@ class ServiceProvidersController < AuthenticatedController
   end
 
   def validate_and_save_service_provider(initial_action)
-    if service_provider.valid?
-      save_service_provider(initial_action)
-    else
-      flash[:error] = error_messages
-      render initial_action
-    end
+    return save_service_provider(initial_action) if service_provider.valid?
+    flash[:error] = error_messages
+    render initial_action
   end
 
   def save_service_provider(initial_action)
@@ -97,7 +94,7 @@ class ServiceProvidersController < AuthenticatedController
 
   # rubocop:disable MethodLength
   def service_provider_params
-    params.require(:service_provider).permit(
+    permit_params = [
       :acs_url,
       :active,
       :agency_id,
@@ -106,18 +103,19 @@ class ServiceProvidersController < AuthenticatedController
       :block_encryption,
       :description,
       :friendly_name,
+      :group_id,
+      :identity_protocol,
       :issuer,
       :logo,
       :metadata_url,
       :return_to_sp_url,
       :saml_client_cert,
       :sp_initiated_login_url,
-      :group_id,
-      :identity_protocol,
-      :production_issuer,
       attribute_bundle: [],
-      redirect_uris: [],
-      )
+      redirect_uris: []
+    ]
+    permit_params << :production_issuer if current_user.admin?
+    params.require(:service_provider).permit(*permit_params)
   end
   # rubocop:enable MethodLength
 

--- a/app/controllers/service_providers_controller.rb
+++ b/app/controllers/service_providers_controller.rb
@@ -114,9 +114,10 @@ class ServiceProvidersController < AuthenticatedController
       :sp_initiated_login_url,
       :group_id,
       :identity_protocol,
+      :production_issuer,
       attribute_bundle: [],
       redirect_uris: [],
-    )
+      )
   end
   # rubocop:enable MethodLength
 

--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -12,6 +12,9 @@
       disabled: !can_edit_groups?(current_user) %>
   <%= form.input :identity_protocol, as: :radio_buttons, label: "<b>Identity protocol</b><br>We highly recommend using OpenID Connect, unless a technical reason prevents you.<br>".html_safe %>
   <%= form.input :issuer, disabled: form.object.persisted?, label: unless form.object.persisted? then "<b>Issuer</b><br>A unique string to identify the app in the IdP. We recommend something like the following, replacing <code>agency_name</code> and <code>app_name</code> with your own.<br><i>For OpenID Connect:</i><br><code class='ml2'>urn:gov:gsa:openidconnect.profiles:sp:sso:agency_name:app_name</code><br><i>For SAML:</i><br><code class='ml2'>urn:gov:gsa:SAML:2.0.profiles:sp:sso:agency_name:app_name</code>".html_safe else "<b>Issuer</b><br><i>The issuer cannot be changed, but you can create a new test app with a different issuer.</i>".html_safe end %>
+  <% if current_user.admin? %>
+  <%= form.input :production_issuer, label: "<b>Production Issuer</b>".html_safe %>
+  <% end %>
   <%= form.input :logo, placeholder: 'generic.svg', label: "<b>Logo</b><br>The name of the <a href='https://github.com/18F/identity-idp/tree/master/app/assets/images/sp-logos' target='_blank'>logo image file</a> in the IdP. The login.gov team can add this image for you.".html_safe %>
   <%= form.input :saml_client_cert, label: "<b>Public key</b><br>Your public key, needed for OpenID Connect (when using <i>private_key_jwt</i>) and for SAML. This must be <a href='https://en.wikipedia.org/wiki/Privacy-enhanced_Electronic_Mail' target='_blank'>PEM encoded</a>, for example in the form:<br><pre><code>-----BEGIN CERTIFICATE-----<br>MIIDXTCCAkWgAwIBAgIJAJC1HiIAZAiIMA0GCSqGSIb3Df<br>BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVx<br>B7xxt8BVc69rHV15A0qyx77CLSj3tCx2IUXVqRs5mlvA==<br>-----END CERTIFICATE-----</code></pre>".html_safe %>
 <div>

--- a/app/views/service_providers/all.html.erb
+++ b/app/views/service_providers/all.html.erb
@@ -9,6 +9,7 @@
       <th scope="col">Issuer</th>
       <th scope="col">Active</th>
       <th scope="col">Created</th>
+      <th scope="col">In Production</th>
     </tr>
   </thead>
   <tbody>
@@ -18,6 +19,7 @@
       <td><%= app.issuer %></td>
       <td><%= app.active? ? '✔' : '❌' %></td>
       <td><%= app.created_at.localtime.strftime("%F %T") %></td>
+      <td><%= app.production_issuer.present? ? '✔' : '❌' %></td>
     </tr>
     <% end %>
   </tbody>

--- a/app/views/service_providers/show.html.erb
+++ b/app/views/service_providers/show.html.erb
@@ -26,6 +26,12 @@
       <th scope="row">Issuer</th>
       <td><code><%= service_provider.issuer %></code></td>
     </tr>
+    <% if current_user.admin? %>
+    <tr>
+      <th scope="row">Production Issuer</th>
+      <td><code><%= service_provider.production_issuer %></code></td>
+    </tr>
+    <% end %>
     <tr>
       <th scope="row">Logo</th>
       <td><a href="https://github.com/18F/identity-idp/tree/master/app/assets/images/sp-logos/<%= service_provider.logo %>"><%= service_provider.logo %></a></td>

--- a/db/migrate/20181224112751_add_production_issuer_to_service_providers.rb
+++ b/db/migrate/20181224112751_add_production_issuer_to_service_providers.rb
@@ -1,0 +1,5 @@
+class AddProductionIssuerToServiceProviders < ActiveRecord::Migration[4.2]
+  def change
+    add_column :service_providers, :production_issuer, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180309010908) do
+ActiveRecord::Schema.define(version: 20181224112751) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,6 +77,7 @@ ActiveRecord::Schema.define(version: 20180309010908) do
     t.string   "logo"
     t.integer  "identity_protocol",                     default: 0
     t.json     "redirect_uris"
+    t.string   "production_issuer"
   end
 
   add_index "service_providers", ["group_id"], name: "index_service_providers_on_group_id", using: :btree

--- a/spec/features/service_providers_spec.rb
+++ b/spec/features/service_providers_spec.rb
@@ -129,7 +129,8 @@ feature 'Service Providers CRUD' do
 
       select group, from: 'service_provider[group_id]'
       fill_in 'Friendly name', with: 'test service_provider'
-      fill_in 'Issuer', with: 'urn:gov:gsa:openidconnect.profiles:sp:sso:ABC:my-cool-app'
+      fill_in 'Issuer', with: 'urn:gov:gsa:openidconnect.profiles:sp:sso:ABC:my-cool-app',
+              :match => :prefer_exact
       check 'email'
       check 'first_name'
       click_on 'Create'


### PR DESCRIPTION
Admins can indicate which apps are live by editing the production_issuer for any app. There is no standardized naming for issuer so there is no way to automate the identification of which apps are in production. Rather than simply providing a boolean for the app, a production issuer will allow us to provide a reference to the prod issuers.