### PR TITLE
Add IAL attribute to service providers.

### DIFF
--- a/app/controllers/service_providers_controller.rb
+++ b/app/controllers/service_providers_controller.rb
@@ -104,6 +104,7 @@ class ServiceProvidersController < AuthenticatedController
       :description,
       :friendly_name,
       :group_id,
+      :ial,
       :identity_protocol,
       :issuer,
       :logo,

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -26,10 +26,23 @@ class ServiceProvider < ApplicationRecord
   validate :redirect_uris_are_parsable
   validate :saml_client_cert_is_x509_if_present
 
+  validates :ial, inclusion: { in: [1, 2] }
+
   before_validation(on: %i(create update)) do
     self.attribute_bundle = attribute_bundle.reject(&:blank?) if attribute_bundle.present?
   end
   # before_validation :build_issuer, on: :create
+
+  def ial_friendly
+    case ial
+    when 1, nil
+      'IAL1'
+    when 2
+      'IAL2'
+    else
+      ial.inspect
+    end
+  end
 
   def issuer_department
     @issuer_department || ServiceProviderIssuerParser.new(issuer).parse[:department]

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -26,7 +26,7 @@ class ServiceProvider < ApplicationRecord
   validate :redirect_uris_are_parsable
   validate :saml_client_cert_is_x509_if_present
 
-  validates :ial, inclusion: { in: [1, 2] }
+  validates :ial, inclusion: { in: [1, 2] }, allow_nil: true
 
   before_validation(on: %i(create update)) do
     self.attribute_bundle = attribute_bundle.reject(&:blank?) if attribute_bundle.present?

--- a/app/serializers/service_provider_serializer.rb
+++ b/app/serializers/service_provider_serializer.rb
@@ -7,6 +7,7 @@ class ServiceProviderSerializer < ActiveModel::Serializer
     :block_encryption,
     :cert,
     :friendly_name,
+    :ial,
     :issuer,
     :logo,
     :redirect_uris,

--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -11,6 +11,10 @@
       label: "<b>Group</b><br>The agency group you would like this client to be assigned to.".html_safe,
       disabled: !can_edit_groups?(current_user) %>
   <%= form.input :identity_protocol, as: :radio_buttons, label: "<b>Identity protocol</b><br>We highly recommend using OpenID Connect, unless a technical reason prevents you.<br>".html_safe %>
+
+  <%= form.label(:ial, '<b>Identity verification level (IAL)</b><br>Choose IAL 1 for standard MFA-protected email-based login.<br>Choose IAL 2 for identity proofed accounts that require SSN and identity verification (aka LOA3).<br>'.html_safe) %>
+  <%= form.select(:ial, options_for_select([['IAL1 (standard)', 1], ['IAL2 (verified identity with SSN)', 2]])).html_safe %>
+
   <%= form.input :issuer, disabled: form.object.persisted?, label: unless form.object.persisted? then "<b>Issuer</b><br>A unique string to identify the app in the IdP. We recommend something like the following, replacing <code>agency_name</code> and <code>app_name</code> with your own.<br><i>For OpenID Connect:</i><br><code class='ml2'>urn:gov:gsa:openidconnect.profiles:sp:sso:agency_name:app_name</code><br><i>For SAML:</i><br><code class='ml2'>urn:gov:gsa:SAML:2.0.profiles:sp:sso:agency_name:app_name</code>".html_safe else "<b>Issuer</b><br><i>The issuer cannot be changed, but you can create a new test app with a different issuer.</i>".html_safe end %>
   <% if current_user.admin? %>
   <%= form.input :production_issuer, label: "<b>Production Issuer</b>".html_safe %>
@@ -35,7 +39,7 @@
 
 <fieldset class="usa-fieldset-inputs">
   <legend>Attribute bundle</legend>
-  <p>The possible <a href="https://developers.login.gov/attributes" target="_blank">user attributes</a> to be requested by your app. Note for LOA1, only UUID and email can be requested.</p>
+  <p>The possible <a href="https://developers.login.gov/attributes" target="_blank">user attributes</a> to be requested by your app. Note for IAL1/LOA1, only UUID and email can be requested.</p>
     <%= collection_check_boxes(:service_provider,
         :attribute_bundle,
         ServiceProvider.possible_attributes, :first, :last) do |b| %>

--- a/app/views/service_providers/all.html.erb
+++ b/app/views/service_providers/all.html.erb
@@ -7,6 +7,7 @@
     <tr>
       <th scope="col">Friendly name</th>
       <th scope="col">Issuer</th>
+      <th scope="col">IAL</th>
       <th scope="col">Active</th>
       <th scope="col">Created</th>
       <th scope="col">In Production</th>
@@ -17,6 +18,7 @@
     <tr>
       <th scope="row"><%= link_to(app.friendly_name, service_provider_path(app)) %></th>
       <td><%= app.issuer %></td>
+      <td><%= app.ial_friendly %></td>
       <td><%= app.active? ? '✔' : '❌' %></td>
       <td><%= app.created_at.localtime.strftime("%F %T") %></td>
       <td><%= app.production_issuer.present? ? '✔' : '❌' %></td>

--- a/app/views/service_providers/index.html.erb
+++ b/app/views/service_providers/index.html.erb
@@ -7,6 +7,7 @@
     <tr>
       <th scope="col">Friendly name</th>
       <th scope="col">Issuer</th>
+      <th scope="col">IAL</th>
       <th scope="col">Active</th>
     </tr>
   </thead>
@@ -15,6 +16,7 @@
     <tr>
       <th scope="row"><%= link_to(app.friendly_name, service_provider_path(app)) %></th>
       <td><%= app.issuer %></td>
+      <td><%= app.ial_friendly %></td>
       <td><%= app.active? ? '✔' : '❌' %></td>
     </tr>
     <% end %>

--- a/app/views/service_providers/show.html.erb
+++ b/app/views/service_providers/show.html.erb
@@ -23,6 +23,10 @@
       <td><%= service_provider.identity_protocol %></td>
     </tr>
     <tr>
+      <th scope="row">Identity verification level (IAL)</th>
+      <td><%= service_provider.ial_friendly %></td>
+    </tr>
+    <tr>
       <th scope="row">Issuer</th>
       <td><code><%= service_provider.issuer %></code></td>
     </tr>

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -14,6 +14,7 @@ en:
         block_encryption: Block Encryption
         description: Description
         friendly_name: Friendly name
+        ial: Identity Assurance Level (IAL1 or IAL2)
         issuer: Issuer
         logo: Logo
         redirect_uris: Redirect URIs (for OpenID Connect)

--- a/db/migrate/20190320210340_add_ial_to_service_providers.rb
+++ b/db/migrate/20190320210340_add_ial_to_service_providers.rb
@@ -1,0 +1,5 @@
+class AddIalToServiceProviders < ActiveRecord::Migration[5.1]
+  def change
+    add_column :service_providers, :ial, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,107 +10,96 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181224112751) do
+ActiveRecord::Schema.define(version: 20190320210340) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "agencies", force: :cascade do |t|
-    t.string   "name",       null: false
+    t.string "name", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-  end
-
-  add_index "agencies", ["name"], name: "index_agencies_on_name", unique: true, using: :btree
-
-  create_table "ar_internal_metadata", primary_key: "key", force: :cascade do |t|
-    t.string   "value"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_agencies_on_name", unique: true
   end
 
   create_table "delayed_jobs", force: :cascade do |t|
-    t.integer  "priority",   default: 0, null: false
-    t.integer  "attempts",   default: 0, null: false
-    t.text     "handler",                null: false
-    t.text     "last_error"
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
     t.datetime "run_at"
     t.datetime "locked_at"
     t.datetime "failed_at"
-    t.string   "locked_by"
-    t.string   "queue"
+    t.string "locked_by"
+    t.string "queue"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
-
-  add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
 
   create_table "groups", force: :cascade do |t|
-    t.datetime "created_at",               null: false
-    t.datetime "updated_at",               null: false
-    t.string   "name",                     null: false
-    t.text     "description", default: ""
-  end
-
-  add_index "groups", ["name"], name: "index_groups_on_name", unique: true, using: :btree
-
-  create_table "service_providers", force: :cascade do |t|
-    t.integer  "user_id",                                               null: false
-    t.string   "issuer",                                                null: false
-    t.string   "friendly_name",                                         null: false
-    t.text     "description"
-    t.text     "metadata_url"
-    t.text     "acs_url"
-    t.text     "assertion_consumer_logout_service_url"
-    t.text     "saml_client_cert"
-    t.integer  "block_encryption",                      default: 1,     null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.boolean  "active",                                default: true,  null: false
-    t.boolean  "approved",                              default: false, null: false
-    t.text     "sp_initiated_login_url"
-    t.text     "return_to_sp_url"
-    t.integer  "agency_id"
-    t.json     "attribute_bundle"
-    t.integer  "group_id"
-    t.string   "logo"
-    t.integer  "identity_protocol",                     default: 0
-    t.json     "redirect_uris"
-    t.string   "production_issuer"
-  end
-
-  add_index "service_providers", ["group_id"], name: "index_service_providers_on_group_id", using: :btree
-  add_index "service_providers", ["issuer"], name: "index_service_providers_on_issuer", unique: true, using: :btree
-
-  create_table "user_groups", force: :cascade do |t|
-    t.integer  "user_id"
-    t.integer  "group_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "name", null: false
+    t.text "description", default: ""
+    t.index ["name"], name: "index_groups_on_name", unique: true
   end
 
-  add_index "user_groups", ["group_id"], name: "index_user_groups_on_group_id", using: :btree
-  add_index "user_groups", ["user_id"], name: "index_user_groups_on_user_id", using: :btree
-
-  create_table "users", force: :cascade do |t|
-    t.string   "uuid"
-    t.string   "email",                              null: false
-    t.string   "first_name"
-    t.string   "last_name"
+  create_table "service_providers", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "issuer", null: false
+    t.string "friendly_name", null: false
+    t.text "description"
+    t.text "metadata_url"
+    t.text "acs_url"
+    t.text "assertion_consumer_logout_service_url"
+    t.text "saml_client_cert"
+    t.integer "block_encryption", default: 1, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "sign_in_count",      default: 0,     null: false
-    t.datetime "current_sign_in_at"
-    t.datetime "last_sign_in_at"
-    t.inet     "current_sign_in_ip"
-    t.inet     "last_sign_in_ip"
-    t.boolean  "admin",              default: false, null: false
-    t.integer  "group_id"
+    t.boolean "active", default: true, null: false
+    t.boolean "approved", default: false, null: false
+    t.text "sp_initiated_login_url"
+    t.text "return_to_sp_url"
+    t.integer "agency_id"
+    t.json "attribute_bundle"
+    t.integer "group_id"
+    t.string "logo"
+    t.integer "identity_protocol", default: 0
+    t.json "redirect_uris"
+    t.string "production_issuer"
+    t.integer "ial"
+    t.index ["group_id"], name: "index_service_providers_on_group_id"
+    t.index ["issuer"], name: "index_service_providers_on_issuer", unique: true
   end
 
-  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
-  add_index "users", ["group_id"], name: "index_users_on_group_id", using: :btree
-  add_index "users", ["uuid"], name: "index_users_on_uuid", unique: true, using: :btree
+  create_table "user_groups", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "group_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_user_groups_on_group_id"
+    t.index ["user_id"], name: "index_user_groups_on_user_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "uuid"
+    t.string "email", null: false
+    t.string "first_name"
+    t.string "last_name"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.inet "current_sign_in_ip"
+    t.inet "last_sign_in_ip"
+    t.boolean "admin", default: false, null: false
+    t.integer "group_id"
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["group_id"], name: "index_users_on_group_id"
+    t.index ["uuid"], name: "index_users_on_uuid", unique: true
+  end
 
   add_foreign_key "service_providers", "agencies"
   add_foreign_key "service_providers", "groups"

--- a/spec/factories/service_providers.rb
+++ b/spec/factories/service_providers.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :service_provider do
-    ial { 1 }
     sequence(:friendly_name) { |n| "test-service_provider-#{n}" }
     sequence(:issuer) { |n| "urn:gov:gsa:SAML:2.0.profiles:sp:sso:DEPT:APP-#{n}" }
     sequence(:description) { |n| "test service_provider description #{n}" }

--- a/spec/factories/service_providers.rb
+++ b/spec/factories/service_providers.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :service_provider do
+    ial { 1 }
     sequence(:friendly_name) { |n| "test-service_provider-#{n}" }
     sequence(:issuer) { |n| "urn:gov:gsa:SAML:2.0.profiles:sp:sso:DEPT:APP-#{n}" }
     sequence(:description) { |n| "test service_provider description #{n}" }


### PR DESCRIPTION
This is a dependency for https://github.com/18F/identity-idp/pull/2672

The IDP will soon start enforcing validation such that IAL1 service
providers can only request IAL1 attributes, not sensitive attributes.

By default the IDP will consider service providers to be at IAL1. So in
order to avoid any service providers that are relying upon IAL2/LOA3
data, we have to add a corresponding attribute to service providers in
the dashboard.