### PR TITLE
Minor tweak to form to use cert instead of key

### DIFF
--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -16,7 +16,7 @@
   <%= form.input :production_issuer, label: "<b>Production Issuer</b>".html_safe %>
   <% end %>
   <%= form.input :logo, placeholder: 'generic.svg', label: "<b>Logo</b><br>The name of the <a href='https://github.com/18F/identity-idp/tree/master/app/assets/images/sp-logos' target='_blank'>logo image file</a> in the IdP. The login.gov team can add this image for you.".html_safe %>
-  <%= form.input :saml_client_cert, label: "<b>Public key</b><br>Your public key, needed for OpenID Connect (when using <i>private_key_jwt</i>) and for SAML. This must be <a href='https://en.wikipedia.org/wiki/Privacy-enhanced_Electronic_Mail' target='_blank'>PEM encoded</a>, for example in the form:<br><pre><code>-----BEGIN CERTIFICATE-----<br>MIIDXTCCAkWgAwIBAgIJAJC1HiIAZAiIMA0GCSqGSIb3Df<br>BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVx<br>B7xxt8BVc69rHV15A0qyx77CLSj3tCx2IUXVqRs5mlvA==<br>-----END CERTIFICATE-----</code></pre>".html_safe %>
+  <%= form.input :saml_client_cert, label: "<b>Public certificate</b><br>Your public certificate, which contains your public key, is needed for OpenID Connect (when using <i>private_key_jwt</i>) and for SAML. This must be <a href='https://en.wikipedia.org/wiki/Privacy-enhanced_Electronic_Mail' target='_blank'>PEM encoded</a>, for example in the form:<br><pre><code>-----BEGIN CERTIFICATE-----<br>MIIDXTCCAkWgAwIBAgIJAJC1HiIAZAiIMA0GCSqGSIb3Df<br>BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVx<br>B7xxt8BVc69rHV15A0qyx77CLSj3tCx2IUXVqRs5mlvA==<br>-----END CERTIFICATE-----</code></pre>".html_safe %>
 <div>
 
 <div class="saml-fields">

--- a/app/views/service_providers/show.html.erb
+++ b/app/views/service_providers/show.html.erb
@@ -57,7 +57,7 @@
     <% end %>
 
     <tr>
-      <th scope="row">Public key</th>
+      <th scope="row">Public certificate</th>
       <td><pre><code><%= service_provider.saml_client_cert %></code></pre></td>
     </tr>
     <tr>


### PR DESCRIPTION
Using "public key" is a little misleading since we're actually asking for the public certificate. Added more clear language to state this. 