### PR TITLE
LG-1035 - Updates formatting for redirect URIs

### DIFF
--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -28,6 +28,7 @@ class ServiceProvider < ApplicationRecord
 
   before_validation(on: %i(create update)) do
     self.attribute_bundle = attribute_bundle.reject(&:blank?) if attribute_bundle.present?
+    format_redirect_uris
   end
 
   def ial_friendly
@@ -88,6 +89,11 @@ class ServiceProvider < ApplicationRecord
     parsed_uri.scheme.present? || parsed_uri.host.present?
   rescue URI::BadURIError, URI::InvalidURIError
     false
+  end
+
+  def format_redirect_uris
+    return if redirect_uris.nil?
+    redirect_uris.map(&:downcase!)
   end
 
   def saml_client_cert_is_x509_if_present

--- a/spec/models/service_provider_spec.rb
+++ b/spec/models/service_provider_spec.rb
@@ -90,6 +90,14 @@ describe ServiceProvider do
       expect(bad_uri_sp).to_not be_valid
     end
 
+    it 'forces URLs to be lowercase' do
+      sp = build(:service_provider, redirect_uris: [
+        'https://ServiceProvider.domain.com/AuthRoute/Callback'])
+
+      expect(sp).to be_valid
+      expect(sp.redirect_uris.first).to eq('https://serviceprovider.domain.com/authroute/callback')
+    end
+
     it 'allows redirect_uris to be empty' do
       sp = build(:service_provider, redirect_uris: [])
       expect(sp).to be_valid


### PR DESCRIPTION
Forces URIs to be lowercase. That's it. 

This solves issues with CSP errors where the redirect is to a lowercase URI despite the whitelist containing CamelCase. The root cause is the http-level redirect uses lowercase (or is interpreted as lowercase per the spec) but the CSP contains the case-sensitive URI. 
