### PR TITLE
Fixes redirect URI validation

### DIFF
--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -85,7 +85,7 @@ class ServiceProvider < ApplicationRecord
 
   def redirect_uri_valid?(redirect_uri)
     parsed_uri = URI.parse(redirect_uri)
-    parsed_uri.scheme.present? || parsed_uri.host.present?
+    parsed_uri.scheme.present? && parsed_uri.host.present?
   rescue URI::BadURIError, URI::InvalidURIError
     false
   end

--- a/spec/models/service_provider_spec.rb
+++ b/spec/models/service_provider_spec.rb
@@ -83,11 +83,13 @@ describe ServiceProvider do
       missing_protocol_sp = build(:service_provider, redirect_uris: ['foo.com'])
       relative_uri_sp = build(:service_provider, redirect_uris: ['/asdf/hjkl'])
       bad_uri_sp = build(:service_provider, redirect_uris: [' http://foo.com'])
+      malformed_uri_sp = build(:service_provider, redirect_uris: ['super.foo.com:/result'])
 
       expect(valid_sp).to be_valid
       expect(missing_protocol_sp).to_not be_valid
       expect(relative_uri_sp).to_not be_valid
       expect(bad_uri_sp).to_not be_valid
+      expect(malformed_uri_sp).to_not be_valid
     end
 
     it 'allows redirect_uris to be empty' do


### PR DESCRIPTION
This validation should match the IdP: https://github.com/18F/identity-idp/blob/master/app/models/service_provider.rb#L73

This is a quick fix until LG-1410 is implemented to unify this validation for both apps. 