### PR TITLE
LG-939: alphabetize the list of apps in the dashboard

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,9 @@ class User < ApplicationRecord
   end
 
   def scoped_service_providers
-    (member_service_providers + service_providers).uniq
+    (member_service_providers + service_providers).
+      uniq.
+      sort_by! { |sp| sp.friendly_name.downcase }
   end
 
   def domain

--- a/spec/features/groups_spec.rb
+++ b/spec/features/groups_spec.rb
@@ -12,7 +12,6 @@ feature 'User groups CRUD' do
     fill_in 'Name', with: 'team name'
     find("#group_user_ids_#{user.id}").click
 
-
     click_on 'Create'
     expect(current_path).to eq(groups_path)
     expect(page).to have_content('Success')
@@ -89,7 +88,7 @@ feature 'User groups CRUD' do
       admin = create(:admin)
       group = create(:group)
       user = create(:user, groups: [group])
-      sp = create(:service_provider, group: group)
+      create(:service_provider, group: group)
 
       login_as(admin)
       visit groups_path
@@ -103,7 +102,7 @@ feature 'User groups CRUD' do
     scenario 'regular user attempts to view a group' do
       user = create(:user)
       group = create(:group)
-      sp = create(:service_provider, group: group)
+      create(:service_provider, group: group)
 
       login_as(user)
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -35,6 +35,21 @@ describe User do
       create(:service_provider)
       expect(user.scoped_service_providers).to eq([user_sp, group_sp])
     end
+    it "alphabetizes the list of user created and the user's group sps" do
+      group = create(:group)
+      user.groups = [group]
+      user.save
+      sp = {}
+      %i[a G c I e].shuffle.each do |prefix|
+        sp[prefix.downcase] = create(:service_provider,
+                                     user: user, friendly_name: "#{prefix}_service_provider")
+      end
+      %i[f B h D j].shuffle.each do |prefix|
+        sp[prefix.downcase] = create(:service_provider,
+                                     group: group, friendly_name: "#{prefix}_service_provider")
+      end
+      expect(user.scoped_service_providers).to eq(sp.keys.sort.map { |k| sp[k] })
+    end
   end
 
   describe '#scoped_groups' do

--- a/spec/requests/service_provider_api_spec.rb
+++ b/spec/requests/service_provider_api_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'Service Provider API' do
   it 'returns JSON' do
     app = create(:service_provider)
-    get '/api/service_providers'
+    get api_service_providers_path
     json = JSON.parse(response.body)
     expect(response).to be_success
     expect(json[0]['issuer']).to eq(app.issuer)


### PR DESCRIPTION
As a Partner developer who is managing my applications in the Partner dashboard, I want a predictable ordering so it's easier for me to find the application I need to manage.

Before:
<img width="1229" alt="Screen Shot 2019-07-17 at 10 35 37 AM" src="https://user-images.githubusercontent.com/2583060/61384586-e900cc00-a87e-11e9-96ee-0f16a715c7d7.png">


After:
<img width="1226" alt="Screen Shot 2019-07-17 at 10 35 54 AM" src="https://user-images.githubusercontent.com/2583060/61384602-f28a3400-a87e-11e9-8943-ca8c9e998315.png">
