### PR TITLE
LG-1272: add push_notification_url to service providers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,10 +12,10 @@ GIT
 
 GIT
   remote: https://github.com/18f/identity-validations.git
-  revision: d112abe3707b62ee53987dfbdc89faa70a4c976f
+  revision: 087594b98207a412a9a3458fd475859a8169f37c
   branch: master
   specs:
-    identity_validations (0.1.0)
+    identity_validations (0.2.0)
 
 GIT
   remote: https://github.com/18f/omniauth_login_dot_gov.git

--- a/app/controllers/service_providers_controller.rb
+++ b/app/controllers/service_providers_controller.rb
@@ -114,6 +114,7 @@ class ServiceProvidersController < AuthenticatedController
       :metadata_url,
       :return_to_sp_url,
       :failure_to_proof_url,
+      :push_notification_url,
       :saml_client_cert,
       :sp_initiated_login_url,
       attribute_bundle: [],

--- a/app/serializers/service_provider_serializer.rb
+++ b/app/serializers/service_provider_serializer.rb
@@ -14,6 +14,7 @@ class ServiceProviderSerializer < ActiveModel::Serializer
     :redirect_uris,
     :return_to_sp_url,
     :failure_to_proof_url,
+    :push_notification_url,
     :signature,
     :sp_initiated_login_url,
     :updated_at

--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -33,6 +33,14 @@
 <%= form.input :return_to_sp_url, input_html: { class: 'h4p4' }, label: "<b>Return to App URL</b><br>The applications URL which login.gov provides to users when they wish to go directly to the app's site or cancel out of authentication. For example: <code>https://app.agency.gov</code>".html_safe %>
 <%= form.input :failure_to_proof_url, input_html: { class: 'h4p4' }, label: "<b>Failure to Proof URL</b><br><i>IAL2 Only</i> — The URL provided to users who are unable to complete identity proofing and returning to your application.".html_safe %>
 
+  <%# TODO: When merging this in with the changes from LG-1335, uncomment this version... %>
+  <%# form.input :push_notification_url,
+                 input_html: { class: 'usa-input' },
+                 label: 'Push notification URL',
+                 hint: "Your application's endpoint which receives push notifications." %>
+  <%# TODO: ... and delete the following: %>
+  <%= form.input :push_notification_url, input_html: { class: 'h4p4' }, label: "<b>Push Notification URL</b><br>Your application's endpoint which receives push notifications.".html_safe %>
+
 <div class="oidc-fields">
   <%= form.label :redirect_uris, "<b>Redirect URIs</b><br>One or more URIs that login.gov will redirect to after authentication. These can be web URLs (public, internal, or localhost) or a custom scheme to support native applications, for example: <code>gov.agency.app://result</code>".html_safe %>
 </div>
@@ -54,6 +62,7 @@
         <%= b.label %>
     <% end %>
 </fieldset>
+
 
 <%= form.input :active, as: :radio_buttons, label: "<b>Active</b><br>Use to activate or deactivate the app.<br>".html_safe %>
 

--- a/app/views/service_providers/show.html.erb
+++ b/app/views/service_providers/show.html.erb
@@ -76,6 +76,10 @@
       <th scope="row">Failure to Proof URL</th>
       <td><%= service_provider.failure_to_proof_url %></td>
     </tr>
+    <tr>
+      <th scope="row">Push Notification URL</th>
+      <td><%= service_provider.push_notification_url %></td>
+    </tr>
 
     <tr>
       <% if service_provider.identity_protocol == 'openid_connect' %>

--- a/db/migrate/20190805160021_add_push_notification_url_to_service_provider.rb
+++ b/db/migrate/20190805160021_add_push_notification_url_to_service_provider.rb
@@ -1,0 +1,6 @@
+# Add push_notification_url to service_provider
+class AddPushNotificationUrlToServiceProvider < ActiveRecord::Migration[5.1]
+  def change
+    add_column :service_providers, :push_notification_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,19 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190725184319) do
+ActiveRecord::Schema.define(version: 20190805160021) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "agencies", force: :cascade do |t|
+  create_table "agencies", id: :serial, force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["name"], name: "index_agencies_on_name", unique: true
   end
 
-  create_table "delayed_jobs", force: :cascade do |t|
+  create_table "delayed_jobs", id: :serial, force: :cascade do |t|
     t.integer "priority", default: 0, null: false
     t.integer "attempts", default: 0, null: false
     t.text "handler", null: false
@@ -37,7 +37,7 @@ ActiveRecord::Schema.define(version: 20190725184319) do
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
-  create_table "groups", force: :cascade do |t|
+  create_table "groups", id: :serial, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name", null: false
@@ -46,7 +46,7 @@ ActiveRecord::Schema.define(version: 20190725184319) do
     t.index ["name"], name: "index_groups_on_name", unique: true
   end
 
-  create_table "service_providers", force: :cascade do |t|
+  create_table "service_providers", id: :serial, force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "issuer", null: false
     t.string "friendly_name", null: false
@@ -71,11 +71,12 @@ ActiveRecord::Schema.define(version: 20190725184319) do
     t.string "production_issuer"
     t.integer "ial"
     t.string "failure_to_proof_url"
+    t.string "push_notification_url"
     t.index ["group_id"], name: "index_service_providers_on_group_id"
     t.index ["issuer"], name: "index_service_providers_on_issuer", unique: true
   end
 
-  create_table "user_groups", force: :cascade do |t|
+  create_table "user_groups", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.integer "group_id"
     t.datetime "created_at", null: false
@@ -84,7 +85,7 @@ ActiveRecord::Schema.define(version: 20190725184319) do
     t.index ["user_id"], name: "index_user_groups_on_user_id"
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", id: :serial, force: :cascade do |t|
     t.string "uuid"
     t.string "email", null: false
     t.string "first_name"

--- a/spec/features/service_providers_spec.rb
+++ b/spec/features/service_providers_spec.rb
@@ -109,7 +109,7 @@ feature 'Service Providers CRUD' do
       choose 'Saml'
 
       saml_attributes =
-        %w[acs_url assertion_consumer_logout_service_url sp_initiated_login_url return_to_sp_url failure_to_proof_url]
+        %w[acs_url assertion_consumer_logout_service_url sp_initiated_login_url return_to_sp_url failure_to_proof_url push_notification_url]
       saml_attributes.each do |atr|
         expect(page).to have_content(t("simple_form.labels.service_provider.#{atr}"))
       end
@@ -126,7 +126,7 @@ feature 'Service Providers CRUD' do
       choose 'Openid connect'
 
       saml_attributes =
-        %w[acs_url assertion_consumer_logout_service_url sp_initiated_login_url return_to_sp_url failure_to_proof_url]
+        %w[acs_url assertion_consumer_logout_service_url sp_initiated_login_url return_to_sp_url failure_to_proof_url push_notification_url]
       saml_attributes.each do |atr|
         expect(page).to_not have_content(t("simple_form.labels.service_provider.#{atr}"))
       end

--- a/spec/models/service_provider_spec.rb
+++ b/spec/models/service_provider_spec.rb
@@ -117,12 +117,14 @@ describe ServiceProvider do
       relative_uri_sp = build(:service_provider, redirect_uris: ['/asdf/hjkl'])
       bad_uri_sp = build(:service_provider, redirect_uris: [' http://foo.com'])
       malformed_uri_sp = build(:service_provider, redirect_uris: ['super.foo.com:/result'])
+      file_uri_sp = build(:service_provider, redirect_uris: ['file:///usr/sbin/evil_script.sh'])
 
       expect(valid_sp).to be_valid
       expect(missing_protocol_sp).to_not be_valid
       expect(relative_uri_sp).to_not be_valid
       expect(bad_uri_sp).to_not be_valid
       expect(malformed_uri_sp).to_not be_valid
+      expect(file_uri_sp).to_not be_valid
     end
 
     it 'validates that the failure_to_proof_url is an absolute, parsable uri' do
@@ -131,12 +133,30 @@ describe ServiceProvider do
       relative_uri_sp = build(:service_provider, failure_to_proof_url: '/asdf/hjkl')
       bad_uri_sp = build(:service_provider, failure_to_proof_url: ' http://foo.com')
       malformed_uri_sp = build(:service_provider, failure_to_proof_url: 'super.foo.com:/result')
+      file_uri_sp = build(:service_provider, failure_to_proof_url: 'file:///usr/sbin/evil_script.sh')
 
       expect(valid_sp).to be_valid
       expect(missing_protocol_sp).to_not be_valid
       expect(relative_uri_sp).to_not be_valid
       expect(bad_uri_sp).to_not be_valid
       expect(malformed_uri_sp).to_not be_valid
+      expect(file_uri_sp).to_not be_valid
+    end
+
+    it 'validates that the push_notification_url is an absolute, parsable uri' do
+      valid_sp = build(:service_provider, push_notification_url: 'http://foo.com')
+      missing_protocol_sp = build(:service_provider, push_notification_url: 'foo.com')
+      relative_uri_sp = build(:service_provider, push_notification_url: '/asdf/hjkl')
+      bad_uri_sp = build(:service_provider, push_notification_url: ' http://foo.com')
+      malformed_uri_sp = build(:service_provider, push_notification_url: 'super.foo.com:/result')
+      file_uri_sp = build(:service_provider, push_notification_url: 'file:///usr/sbin/evil_script.sh')
+
+      expect(valid_sp).to be_valid
+      expect(missing_protocol_sp).to_not be_valid
+      expect(relative_uri_sp).to_not be_valid
+      expect(bad_uri_sp).to_not be_valid
+      expect(malformed_uri_sp).to_not be_valid
+      expect(file_uri_sp).to_not be_valid
     end
 
     it 'allows redirect_uris to be empty' do


### PR DESCRIPTION
As a partner developer, I want to have a self-service way to configure push notifications in the dashboard, so that I don't have to email Amos or Steve to do it.

Note: ~requires the merging of https://github.com/18F/identity-validations/pull/2 for specs to pass.~ validation gem has been updated and merged.
Note: since we haven't yet merged in the style guide application from LG-1335, there is a TODO in the form partial for how to make the switch.