### PR TITLE
LG-1641: example push_notification endpoint to test against IDP

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,4 +12,8 @@ class ApplicationController < ActionController::Base
   def render_401
     render file: 'public/401.html', status: :unauthorized
   end
+
+  def not_found
+    render(file: 'public/404.html', status: :not_found, layout: nil) and return
+  end
 end

--- a/app/controllers/push_notification_controller.rb
+++ b/app/controllers/push_notification_controller.rb
@@ -1,0 +1,37 @@
+# These endpoints are only for manually testing push notifications from the IDP
+class PushNotificationController < ApplicationController
+  protect_from_forgery except: :push_notification
+  before_action :development_only
+
+  EVENT_TYPE_URI = 'https://schemas.openid.net/secevent/risc/event-type/account-purged'.freeze
+
+  def push_notification
+    authorization = request.headers['authorization']
+    token = authorization.match(/WebPush (.*)/)[1]
+
+    @decoded_token = JSON::JWT.decode(token, public_jwk)
+    puts "\nReceived JWT token:"
+    pp @decoded_token
+
+    user = User.where(uuid: @decoded_token['events'][EVENT_TYPE_URI]['subject']['sub']).first
+    puts "\nFound deleted user:"
+    pp user
+  end
+
+  private
+
+  def public_keys
+    return @public_keys if @public_keys
+
+    certs_json = HTTParty.get('http://localhost:3000/api/openid_connect/certs').body
+    @public_keys = JSON.parse(certs_json).deep_symbolize_keys
+  end
+
+  def public_jwk
+    JSON::JWK.new(public_keys[:keys][0])
+  end
+
+  def development_only
+    not_found unless Rails.env.development?
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,5 +18,9 @@ Rails.application.routes.draw do
   post '/api/service_providers' => 'api/service_providers#update'
   resources :service_providers
 
+  if Rails.env.development?
+    post '/push_notification' => 'push_notification#push_notification'
+  end
+
   root to: 'home#index'
 end


### PR DESCRIPTION
This allows the dashboard to receive push notifications from the IDP and print the deleted user's details to STDOUT. It's only active in `development` so I thought it would be useful to keep around.