### PR TITLE
LG-1815 Generate yaml blob for sp

### DIFF
--- a/app/helpers/service_provider_helper.rb
+++ b/app/helpers/service_provider_helper.rb
@@ -1,4 +1,18 @@
+#:reek:UtilityFunction
 module ServiceProviderHelper
+  SP_PROTECTED_ATTRIBUTES = %w[
+    id
+    created_at
+    updated_at
+    user_id
+    description
+    approved
+    active
+    group_id
+    identity_protocol
+    production_issuer
+  ].freeze
+
   def sp_logo(file_name)
     file = file_name || 'generic.svg'
     if file.end_with?('.svg')
@@ -18,5 +32,23 @@ module ServiceProviderHelper
     file = file_name || 'generic.svg'
     'https://github.com/18F/identity-idp/blob/master/app/assets/images/sp-logos/' +
       file
+  end
+
+  #:reek:DuplicateMethodCall
+  def yamlized_sp(service_provider)
+    key_from_issuer = JSON.parse(service_provider.to_json).dig('production_issuer').presence ||
+                      clean_sp_hash(service_provider).dig('issuer')
+    yamlable_json = { key_from_issuer => clean_sp_hash(service_provider).except('issuer') }
+    yamlable_json.to_yaml
+  end
+
+  private
+
+  #:reek:DuplicateMethodCall
+  def clean_sp_hash(service_provider)
+    clean_sp_json = service_provider.to_json(except: SP_PROTECTED_ATTRIBUTES)
+    hash_from_clean_json = JSON.parse(clean_sp_json)
+    hash_from_clean_json['agency'] = service_provider.agency.name if service_provider.agency
+    hash_from_clean_json
   end
 end

--- a/app/helpers/service_provider_helper.rb
+++ b/app/helpers/service_provider_helper.rb
@@ -56,7 +56,7 @@ module ServiceProviderHelper
 
   def formatted_config_hash(sp_json)
     sp_json.map do |config_key, value|
-      if %w[agency_id default_help_text attribute_bundle].include?(config_key)
+      if %w[agency_id default_help_text attribute_bundle redirect_uris].include?(config_key)
         [config_key, value]
       else
         [config_key, "'#{value}'"]

--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -158,7 +158,7 @@
       and use UL for checkboxes%>
   <fieldset class='usa-fieldset-inputs usa-fieldset'>
     <legend class='usa-sr-only'>Attribute bundle</legend>
-    <%= form.label :attribute_buntle,
+    <%= form.label :attribute_bundle,
                    label: 'Attribute bundle',
                    class: 'usa-label' %>
     <%= form.hint 'The possible <a href="https://developers.login.gov/attributes" target="_blank">user attributes</a> to be requested by your app. Note for IAL1/LOA1, only UUID and email can be requested.'.html_safe %>

--- a/app/views/service_providers/_service_provider_yaml.erb
+++ b/app/views/service_providers/_service_provider_yaml.erb
@@ -1,6 +1,6 @@
 <p>Use this YAML in <code>service_providers.yml</code> in the IdP to configure this service provider:</p>
 <pre>
   <code>
-    <%= yamlized_sp(@service_provider) if current_user.admin? %>
+    <%= yamlized_sp(@service_provider) %>
   </code>
 </pre>

--- a/app/views/service_providers/_service_provider_yaml.erb
+++ b/app/views/service_providers/_service_provider_yaml.erb
@@ -1,0 +1,6 @@
+<p>Use this YAML in <code>service_providers.yml</code> in the IdP to configure this service provider:</p>
+<pre>
+  <code>
+    <%= yamlized_sp(@service_provider) if current_user.admin? %>
+  </code>
+</pre>

--- a/app/views/service_providers/show.html.erb
+++ b/app/views/service_providers/show.html.erb
@@ -100,6 +100,12 @@
         <%= image_tag service_provider.active? ? 'img/alerts/success.svg' : 'img/alerts/error.svg', height: '27', width: '27', :class =>'margin-bottom-neg-105' %>
       </td>
     </tr>
+    <tr>
+      <th scope="row">Service Provider config as YAML</th>
+      <td>
+        <%= render 'service_provider_yaml' %>
+      </td>
+    </tr>
   </tbody>
 </table>
 <%= button_to t('forms.buttons.edit_service_provider'),

--- a/app/views/service_providers/show.html.erb
+++ b/app/views/service_providers/show.html.erb
@@ -103,7 +103,7 @@
     <tr>
       <th scope="row">Service Provider config as YAML</th>
       <td>
-        <%= render 'service_provider_yaml' %>
+        <%= render 'service_provider_yaml' if current_user.admin? %>
       </td>
     </tr>
   </tbody>

--- a/app/views/service_providers/show.html.erb
+++ b/app/views/service_providers/show.html.erb
@@ -100,12 +100,14 @@
         <%= image_tag service_provider.active? ? 'img/alerts/success.svg' : 'img/alerts/error.svg', height: '27', width: '27', :class =>'margin-bottom-neg-105' %>
       </td>
     </tr>
-    <tr>
-      <th scope="row">Service Provider config as YAML</th>
-      <td>
-        <%= render 'service_provider_yaml' if current_user.admin? %>
-      </td>
-    </tr>
+    <% if current_user.admin? %>
+      <tr>
+        <th scope="row">Service Provider config as YAML</th>
+        <td>
+          <%= render 'service_provider_yaml' %>
+        </td>
+      </tr>
+    <%end %>
   </tbody>
 </table>
 <%= button_to t('forms.buttons.edit_service_provider'),

--- a/spec/factories/service_providers.rb
+++ b/spec/factories/service_providers.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     sequence(:issuer) { |n| "urn:gov:gsa:SAML:2.0.profiles:sp:sso:DEPT:APP-#{n}" }
     sequence(:description) { |n| "test service_provider description #{n}" }
     association :user, factory: :user
+    association :agency, factory: :agency
 
     trait :saml do
       identity_protocol 1

--- a/spec/helpers/service_provider_helper_spec.rb
+++ b/spec/helpers/service_provider_helper_spec.rb
@@ -61,4 +61,33 @@ describe ServiceProviderHelper do
       end
     end
   end
+
+  describe '#yamlized_sp' do
+    let(:sp) { create(:service_provider) }
+    let(:sp_config_protected_attributes) do
+      %w[
+        issuer
+        id
+        created_at
+        updated_at
+        user_id
+        description
+        approved
+        active
+        group_id
+        identity_protocol
+        production_issuer
+      ]
+    end
+    it 'returns the sp issuer in the yaml blurb' do
+      expect(yamlized_sp(sp)).to include(sp.issuer)
+    end
+
+    it 'returns the sp configuration in the yaml blurb' do
+      sp.attribute_names.each do |attribute_name|
+        next if sp_config_protected_attributes.include?(attribute_name)
+        expect(yamlized_sp(sp)).to include(attribute_name)
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Why:** So that anyone who wants to update a Service Provider in the IdP can view a formatted YAML text blob in the dashboard on that Service Provider's details page and be able to paste it directly into the IdP service providers configuration.