### PR TITLE
LG-1840: create an admin user on db:seed

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,3 +9,11 @@
 Rails.application.config.agencies.values.pluck("name").each do |str|
   Agency.find_or_create_by(name: str)
 end
+
+if Rails.env.development? || Rails.env.test?
+  User.find_or_create_by email: 'admin@gsa.gov' do |user|
+    user.first_name = 'Addy'
+    user.last_name = 'Ministrator'
+    user.admin = true
+  end
+end


### PR DESCRIPTION
Why: to ensure that we have a consistent admin account in development.