### PR TITLE
LG-2159: Allow any node version from v8 to v12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,8 @@
 {
+  "engines": {
+    "node": ">=8 <=12",
+    "npm": ">=5 <= 6"
+  },
   "dependencies": {
     "identity-style-guide": "^2.1.3"
   },


### PR DESCRIPTION
**Why?**: to match the conditions placed on the idp.