### PR TITLE
LG-2126 Allow non-admin users to manage groups, add new users to groups

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -25,8 +25,7 @@ class GroupsController < AuthenticatedController
   end
 
   def update
-    update_params = current_user.admin? ? group_params : group_params.merge('user_ids': current_user.id.to_s)
-    if @group.update(update_params)
+    if @group.update(update_params_with_current_user)
       add_new_user
       flash[:success] = 'Success'
       redirect_to group_path(@group.id)
@@ -72,5 +71,13 @@ class GroupsController < AuthenticatedController
 
   def new_user_params
     params.require(:new_user).permit(:email)
+  end
+
+  def update_params_with_current_user
+    if current_user.admin?
+      group_params
+    else
+      group_params.merge('user_ids': (group_params[:user_ids] << current_user.id.to_s))
+    end
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,6 +1,7 @@
-class GroupsController < ApplicationController
-  before_action -> { authorize Group }
-  before_action :find_group, only: %i[show edit update destroy]
+# :reek:InstanceVariableAssumption
+class GroupsController < AuthenticatedController
+  before_action -> { authorize Group }, only: %i[index create new]
+  before_action -> { authorize group }, only: %i[edit update destroy show]
 
   def new
     @group = Group.new
@@ -25,6 +26,7 @@ class GroupsController < ApplicationController
 
   def update
     if @group.update(group_params)
+      add_new_user
       flash[:success] = 'Success'
       redirect_to group_path(@group.id)
     else
@@ -46,11 +48,25 @@ class GroupsController < ApplicationController
 
   private
 
-  def find_group
+  def group
     @group ||= Group.find(params[:id])
   end
 
+  # :reek:DuplicateMethodCall
+  def add_new_user
+    new_user_email = new_user_params[:email]
+    return if new_user_email.blank?
+
+    user = User.find_by(email: new_user_email).presence || User.new(email: new_user_email)
+    @group.users << user unless @group.users.include?(user)
+  end
+
   def group_params
+    params.dig('group', 'user_ids').append(current_user.id.to_s) unless current_user.admin?
     params.require(:group).permit(:name, :agency_id, :description, user_ids: [])
+  end
+
+  def new_user_params
+    params.require(:new_user).permit(:email)
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -25,7 +25,8 @@ class GroupsController < AuthenticatedController
   end
 
   def update
-    if @group.update(group_params)
+    update_params = current_user.admin? ? group_params : group_params.merge('user_ids': current_user.id.to_s)
+    if @group.update(update_params)
       add_new_user
       flash[:success] = 'Success'
       redirect_to group_path(@group.id)
@@ -48,6 +49,10 @@ class GroupsController < AuthenticatedController
 
   private
 
+  def authorize_group
+    authorize group
+  end
+
   def group
     @group ||= Group.find(params[:id])
   end
@@ -62,7 +67,6 @@ class GroupsController < AuthenticatedController
   end
 
   def group_params
-    params.dig('group', 'user_ids').append(current_user.id.to_s) unless current_user.admin?
     params.require(:group).permit(:name, :agency_id, :description, user_ids: [])
   end
 

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -1,24 +1,25 @@
 class GroupPolicy < BasePolicy
-  attr_reader :current_user
+  attr_reader :current_user, :group
 
-  def initialize(current_user, _model)
+  def initialize(current_user, model)
     @current_user = current_user
+    @group = model
   end
 
   def index?
-    admin?
+    true
   end
 
   def show?
-    admin?
+    in_group? || admin?
   end
 
   def update?
-    admin?
+    in_group? || admin?
   end
 
   def edit?
-    admin?
+    in_group? || admin?
   end
 
   def destroy?
@@ -37,5 +38,9 @@ class GroupPolicy < BasePolicy
 
   def admin?
     current_user&.admin?
+  end
+
+  def in_group?
+    @group.users.include?(current_user)
   end
 end

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -14,7 +14,7 @@
   <span class="usa-label margin-bottom-1">Users</span>
 
   <%= form.collection_check_boxes( :user_ids,
-                                 User.all.sorted,
+                                 current_user.admin? ? User.all.sorted : User.select { |u| u.groups.include?(@group) },
                                  :id, :email,
                                  collection_wrapper_tag: :ul,
                                  collection_wrapper_class: 'usa-input-list',

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -19,8 +19,13 @@
                                  collection_wrapper_tag: :ul,
                                  collection_wrapper_class: 'usa-input-list',
                                  item_wrapper_tag: :li) do |b| %>
-        <%=  b.check_box(class: "usa-checkbox__input") %>
+        <%=  b.check_box(class: "usa-checkbox__input", disabled: b.object == current_user && !current_user.admin?) %>
         <%=  b.label(class: "usa-checkbox__label")%>
     <% end %>
+
+  <%= simple_fields_for :new_user do |form| %>
+    <%= form.input :email, label: "Add new group user (email)".html_safe, label_html: { class: 'usa-label' }, input_html: { class: 'usa-input' }, required: false %>
+  <% end %>
+
 </fieldset>
 

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -1,5 +1,5 @@
 <div class="usa-display">Groups</div>
-<%= button_to t('headings.groups.new_group'), new_group_path, method: :get, :class => "usa-button" %>
+<%= button_to t('headings.groups.new_group'), new_group_path, method: :get, :class => "usa-button" if current_user&.admin? %>
 
 <table class="usa-table-borderless groups">
   <thead>
@@ -15,25 +15,26 @@
   <tbody>
     <% @groups.each do |group| %>
       <tr>
-        <th scope="row"><%= group.name %></th>
-        <td><%= group&.agency&.name %></td>
-        <td class="text-wrap"><%= group.description %></td>
-        <td>
-          <% group.service_providers.each do |sp| %>
-            <%= link_to sp.friendly_name, service_provider_path(sp), :class => 'usa-link' %><%= "<br><hr>".html_safe unless sp == group.service_providers.last %>
-          <% end %>
-        </td>
-        <td>
-          <% group.users.each do |user| %>
-            <a href="<%= edit_user_path(user.id) %>" class="usa-link"><%= user.email %></a><br>
-          <% end %>
-        </td>
-        <td class="text-wrap">
-          <%= link_to 'view', group_path(group), :class => 'usa-link' %><br>
-          <%= link_to 'edit', edit_group_path(group), :class => 'usa-link' %><br>
-          <%= link_to 'delete', group_path(group), method: :delete, data: { confirm: 'Are you sure you want to delete this group?' }, :class => 'usa-link' %>
-        </td>
-      </tr>
-    <% end %>
+        <% if current_user&.admin? || group.users.include?(current_user) %>
+          <th scope="row"><%= group.name %></th>
+          <td><%= group&.agency&.name %></td>
+          <td class="text-wrap"><%= group.description %></td>
+          <td>
+            <% group.service_providers.each do |sp| %>
+              <%= link_to sp.friendly_name, service_provider_path(sp), :class => 'usa-link' %><%= "<br><hr>".html_safe unless sp == group.service_providers.last %>
+            <% end %>
+          </td>
+          <td>
+            <% group.users.each do |user| %>
+              <a href="<%= edit_user_path(user.id) %>" class="usa-link"><%= user.email %></a><br>
+            <% end %>
+          </td>
+          <td class="text-wrap">
+            <%= link_to 'view', group_path(group), :class => 'usa-link' %><br>
+            <%= link_to 'edit', edit_group_path(group), :class => 'usa-link' %><br>
+            <%= link_to 'delete', group_path(group), method: :delete, data: { confirm: 'Are you sure you want to delete this group?' }, :class => 'usa-link' if current_user.admin? %>
+          </td>
+        <% end %>
+      <% end %>
   </tbody>
 </table>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -2,7 +2,7 @@
 <ul class="usa-list usa-list--unstyled">
   <li><%= link_to "Back to groups", groups_path, :class => 'usa-link'  %> </li>
 </ul>
-<%= button_to t('headings.groups.new_group'), new_group_path, method: :get, :class => "usa-button margin-top-4" %>
+<%= button_to t('headings.groups.new_group'), new_group_path, method: :get, :class => "usa-button margin-top-4" if current_user.admin? %>
 
 
 <div class="usa-display">Group details for "<%= @group.name %>" </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -122,6 +122,12 @@
                     </li>
                   </ul>
                 </li>
+              <% else %>
+                <li class="usa-nav__primary-item">
+                  <a class="usa-nav__link" href="<%= groups_path %>">
+                    <span>Groups</span>
+                  </a>
+                </li>
               <% end %>
               <li class="usa-nav__primary-item">
                 <a class="usa-nav__link" href="<%= destroy_user_session_path %>">

--- a/spec/features/groups_spec.rb
+++ b/spec/features/groups_spec.rb
@@ -62,6 +62,7 @@ feature 'User groups CRUD' do
 
     fill_in 'Name', with: 'updated team'
     fill_in 'Description', with: 'updated department'
+    fill_in 'Add new group user (email)', with: 'new_user@gsa.gov'
     select('USDS', from: 'Agency')
     click_on 'Update'
 
@@ -70,6 +71,7 @@ feature 'User groups CRUD' do
     expect(page).to have_content('USDS')
     expect(page).to have_content('updated department')
     expect(page).to have_content('updated team')
+    expect(page).to have_content('new_user@gsa.gov')
   end
 
   scenario 'Index' do

--- a/spec/features/nav_links_spec.rb
+++ b/spec/features/nav_links_spec.rb
@@ -22,13 +22,13 @@ feature 'Nav links' do
   end
 
   context 'user is not an admin' do
-    scenario 'user should not see manage user group link' do
+    scenario 'user should see manage user group link' do
       user = create(:user)
 
       login_as(user)
       visit service_providers_path
 
-      expect(page).to_not have_content('Groups')
+      expect(page).to have_content('Groups')
     end
 
     scenario 'user should not see a manage users link' do
@@ -37,7 +37,7 @@ feature 'Nav links' do
       login_as(admin)
       visit service_providers_path
 
-      expect(page).to_not have_content('Groups')
+      expect(page).to_not have_content('Users')
     end
   end
 end

--- a/spec/policies/group_spec.rb
+++ b/spec/policies/group_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+describe GroupPolicy do
+  let(:admin_user) { build(:user, admin: true) }
+  let(:group_user) { build(:user) }
+  let(:other_user) { build(:user) }
+  let(:group)      { build(:group) }
+
+  before do
+    group.users << group_user
+  end
+
+  permissions :create? do
+    it 'allows admin users to create' do
+      expect(GroupPolicy).to permit(admin_user, group)
+    end
+  end
+
+  permissions :edit? do
+    it 'allows group member or admin to edit' do
+      expect(GroupPolicy).to permit(admin_user, group)
+      expect(GroupPolicy).to permit(group_user, group)
+      expect(GroupPolicy).to_not permit(other_user, group)
+    end
+  end
+
+  permissions :update? do
+    it 'allows group member or admin to update' do
+      expect(GroupPolicy).to permit(admin_user, group)
+      expect(GroupPolicy).to permit(group_user, group)
+      expect(GroupPolicy).to_not permit(other_user, group)
+    end
+  end
+
+  permissions :new? do
+    it 'allows admin user to initiate' do
+      expect(GroupPolicy).to permit(admin_user, group)
+      expect(GroupPolicy).to_not permit(group_user, group)
+      expect(GroupPolicy).to_not permit(other_user, group)
+    end
+  end
+
+  permissions :destroy? do
+    it 'allows admin to destroy' do
+      expect(GroupPolicy).to permit(admin_user, group)
+      expect(GroupPolicy).to_not permit(group_user, group)
+      expect(GroupPolicy).to_not permit(other_user, group)
+    end
+  end
+
+  permissions :show? do
+    it 'allows group member or admin to show' do
+      expect(GroupPolicy).to permit(admin_user, group)
+      expect(GroupPolicy).to permit(group_user, group)
+      expect(GroupPolicy).to_not permit(other_user, group)
+    end
+  end
+end


### PR DESCRIPTION
**Why:** Because non-admin users need a way to manage the groups they are members of, and they need the ability to add new users who are not yet in the system directly to their groups.