### PR TITLE
Preserves groups route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,4 +19,7 @@ Rails.application.routes.draw do
   resources :service_providers
 
   root to: 'home#index'
+
+  # preserve old Groups route
+  match '/groups/:id', to: redirect('/teams/%{id}'), via: :get
 end

--- a/spec/requests/preserved_urls_spec.rb
+++ b/spec/requests/preserved_urls_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe 'Preserved URLs' do
+  describe 'groups URL schema' do
+    it 'redirects to the Teams route' do
+      get '/groups/1'
+
+      expect(response.status).to eq(301)
+      expect(response.location).to eq('http://www.example.com/teams/1')
+    end
+  end
+end


### PR DESCRIPTION
Why
We are utilizing 'dashboard group URL' in HubSpot and these links are now broken.

How
Matches /groups/# URLs and redirects to the Teams route.