### PR TITLE
LG-2706 whitelisted users can create/manage teams

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -11,7 +11,7 @@ class TeamsController < AuthenticatedController
   def create
     @team = Team.new(update_params_with_current_user)
     add_new_user
-    
+
     if @team.save
 
       flash[:success] = 'Success'

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -9,7 +9,7 @@ class TeamsController < AuthenticatedController
   end
 
   def create
-    @team = Team.new(team_params)
+    @team = Team.new(update_params_with_current_user)
 
     if @team.save
 

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -10,7 +10,8 @@ class TeamsController < AuthenticatedController
 
   def create
     @team = Team.new(update_params_with_current_user)
-
+    add_new_user
+    
     if @team.save
 
       flash[:success] = 'Success'

--- a/app/controllers/users/omniauth_controller.rb
+++ b/app/controllers/users/omniauth_controller.rb
@@ -6,7 +6,7 @@ module Users
       if @user
         @user.update!(uuid: omniauth_info['uuid'])
         sign_in @user
-        redirect_to service_providers_path
+        redirect_to teams_path
 
       # Can't find an account, tell user to contact login.gov team
       else

--- a/app/helpers/team_helper.rb
+++ b/app/helpers/team_helper.rb
@@ -7,10 +7,14 @@ module TeamHelper
   end
 
   def can_create_teams?(user)
-    WHITELISTED_DOMAINS.any? { |domain| user.email.end_with? domain } || user.admin?
+    whitelisted_user? || user.admin?
   end
 
   def can_delete_team?(user, team)
     team.users.include?(user) || user.admin?
+  end
+
+  def whitelisted_user?
+    WHITELISTED_DOMAINS.any? { |domain| current_user.email.end_with? domain }
   end
 end

--- a/app/helpers/team_helper.rb
+++ b/app/helpers/team_helper.rb
@@ -1,5 +1,15 @@
 module TeamHelper
+  WHITELISTED_DOMAINS =  %w[.mil .gov .fed.us].freeze
   def can_edit_teams?(user)
     !user.teams.empty? || user.admin?
   end
+
+  def can_create_teams?(user)
+   WHITELISTED_DOMAINS.any? { |domain| user.email.end_with? domain } || user.admin?
+  end
+
+  def can_delete_team?(user, team)
+   team.users.include?(user) || user.admin?
+  end
+
 end

--- a/app/helpers/team_helper.rb
+++ b/app/helpers/team_helper.rb
@@ -1,5 +1,6 @@
+#:reek:UtilityFunction
 module TeamHelper
-  WHITELISTED_DOMAINS =  %w[.mil .gov .fed.us].freeze
+  WHITELISTED_DOMAINS = %w[.mil .gov .fed.us].freeze
 
   def can_edit_teams?(user)
     !user.teams.empty? || user.admin?
@@ -12,5 +13,4 @@ module TeamHelper
   def can_delete_team?(user, team)
     team.users.include?(user) || user.admin?
   end
-
 end

--- a/app/helpers/team_helper.rb
+++ b/app/helpers/team_helper.rb
@@ -1,15 +1,16 @@
 module TeamHelper
   WHITELISTED_DOMAINS =  %w[.mil .gov .fed.us].freeze
+
   def can_edit_teams?(user)
     !user.teams.empty? || user.admin?
   end
 
   def can_create_teams?(user)
-   WHITELISTED_DOMAINS.any? { |domain| user.email.end_with? domain } || user.admin?
+    WHITELISTED_DOMAINS.any? { |domain| user.email.end_with? domain } || user.admin?
   end
 
   def can_delete_team?(user, team)
-   team.users.include?(user) || user.admin?
+    team.users.include?(user) || user.admin?
   end
 
 end

--- a/app/policies/team_policy.rb
+++ b/app/policies/team_policy.rb
@@ -1,7 +1,7 @@
 class TeamPolicy < BasePolicy
-  attr_reader :current_user, :team
+  include TeamHelper
 
-  WHITELISTED_DOMAINS = %w[.mil .gov .fed.us].freeze
+  attr_reader :current_user, :team
 
   def initialize(current_user, model)
     @current_user = current_user
@@ -44,9 +44,5 @@ class TeamPolicy < BasePolicy
 
   def in_team?
     @team.users.include?(current_user)
-  end
-
-  def whitelisted_user?
-    WHITELISTED_DOMAINS.any? { |domain| current_user.email.end_with? domain }
   end
 end

--- a/app/policies/team_policy.rb
+++ b/app/policies/team_policy.rb
@@ -1,6 +1,8 @@
 class TeamPolicy < BasePolicy
   attr_reader :current_user, :team
 
+  WHITELISTED_DOMAINS = %w[.mil .gov .fed.us].freeze
+
   def initialize(current_user, model)
     @current_user = current_user
     @team = model
@@ -23,15 +25,15 @@ class TeamPolicy < BasePolicy
   end
 
   def destroy?
-    admin?
+    in_team? || admin?
   end
 
   def create?
-    admin?
+    whitelisted_user? || admin?
   end
 
   def new?
-    admin?
+    whitelisted_user? || admin?
   end
 
   private
@@ -42,5 +44,9 @@ class TeamPolicy < BasePolicy
 
   def in_team?
     @team.users.include?(current_user)
+  end
+
+  def whitelisted_user?
+    WHITELISTED_DOMAINS.any? { |domain| current_user.email.end_with? domain }
   end
 end

--- a/app/views/teams/_teams_list.html.erb
+++ b/app/views/teams/_teams_list.html.erb
@@ -36,7 +36,7 @@
       </div>
       <div class='mobile-lg:grid-col-2 text-right'>
         <%= link_to 'Edit', edit_team_path(team), class: 'usa-button usa-button--outline display-block margin-bottom-1' %>
-        <% if current_user.admin? %>
+        <% if can_delete_team?(current_user, team) %>
           <%=
             link_to(
               'Delete',

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -1,21 +1,31 @@
-<h1 class="usa-display">Welcome, <%= current_user.email %></h1>
+<h1 class='margin-bottom-2'>My teams</h1>
+
 <div>
-  <h2 class='margin-bottom-2'>Teams</h2>
   <% if @teams.count > 0 %>
     <%= render 'teams_list' %>
+    <%=
+      button_to(
+          t('headings.teams.new_team'),
+          new_team_path,
+          method: :get,
+          class: "usa-button margin-top-4",
+          ) if can_create_teams? (current_user)
+    %>
+  <% elsif can_create_teams?(current_user) %>
+    <div class='lg-card'>
+      <div class='grid-row flex-row flex-align-end'>
+        <div class='mobile-lg:grid-col-10'>
+          <h1 class='margin-bottom-05'>Create your first team</h1>
+          <p class='margin-top-05'>Get started with the sandbox environment. Make a team for your integration project.</p>
+        </div>
+          <div class='mobile-lg:grid-col-2 text-right'>
+          <a href="<%= new_team_path %>" class='usa-button usa-button--outline'>Continue</a>
+        </div>
+      </div>
+    </div>
   <% else %>
-  <p>
-    You aren't a part of any teams yet.
-  </p>
+    <p>
+      You aren't a part of any teams yet.
+    </p>
   <% end %>
 </div>
-<% if current_user.admin? %>
-  <%=
-    button_to(
-      t('headings.teams.new_team'),
-      new_team_path,
-      method: :get,
-      class: "usa-button margin-top-4",
-    )
-  %>
-<% end %>

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -45,7 +45,7 @@ SimpleForm.setup do |config|
     # changed input class from field to usa-input
     b.use :input, class: 'block col-12' # usa-input'
     b.use :hint,  wrap_with: { tag: 'div', class: 'usa-form-hint' }
-    b.use :error, wrap_with: { tag: 'div', class: 'usa-error-message margin-top-neg-205' }
+    b.use :error, wrap_with: { tag: 'div', class: 'usa-error-message' }
   end
 
   config.default_wrapper = :vertical_form

--- a/lib/tasks/service_providers.rake
+++ b/lib/tasks/service_providers.rake
@@ -1,4 +1,5 @@
 namespace :service_providers do
+<<<<<<< Updated upstream
   # rubocop:disable Rails/SkipsModelValidations
   task backfill_help_texts: [:environment] do |_task|
     ServiceProvider.find_each do |sp|
@@ -7,3 +8,11 @@ namespace :service_providers do
   end
   # rubocop:enable Rails/SkipsModelValidations
 end
+=======
+  task :backfill_help_texts => [:environment] do |_task, args|
+    ServiceProvider.find_each do |sp|
+      sp.update_attribute(:help_text, { sign_in: {}, sign_up: {}, forgot_password: {} } )
+    end
+  end
+end
+>>>>>>> Stashed changes

--- a/lib/tasks/service_providers.rake
+++ b/lib/tasks/service_providers.rake
@@ -1,5 +1,4 @@
 namespace :service_providers do
-<<<<<<< Updated upstream
   # rubocop:disable Rails/SkipsModelValidations
   task backfill_help_texts: [:environment] do |_task|
     ServiceProvider.find_each do |sp|
@@ -8,11 +7,3 @@ namespace :service_providers do
   end
   # rubocop:enable Rails/SkipsModelValidations
 end
-=======
-  task :backfill_help_texts => [:environment] do |_task, args|
-    ServiceProvider.find_each do |sp|
-      sp.update_attribute(:help_text, { sign_in: {}, sign_up: {}, forgot_password: {} } )
-    end
-  end
-end
->>>>>>> Stashed changes

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "@rails/webpacker": "^4.2.0",
-    "identity-style-guide": "^2.1.3",
+    "identity-style-guide": "^2.2.2",
     "jquery": "^3.4.1",
     "jquery-ujs": "^1.2.2",
     "serialize-javascript": "^2.1.2",

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -89,13 +89,13 @@ describe TeamsController do
 
       context 'when it creates successfully' do
         it 'has a redirect response' do
-          post :create, params: { team: { name: 'unique name' } }
+          post :create, params: { team: { name: 'unique name' }, new_user: { email: '' } }
           expect(response.status).to eq(302)
         end
       end
       context 'when it fails to create' do
         it 'renders #new' do
-          post :create, params: { team: { name: '' } }
+          post :create, params: { team: { name: '' }, new_user: { email: '' } }
           expect(response).to render_template(:new)
         end
       end

--- a/spec/controllers/users/omniauth_controller_spec.rb
+++ b/spec/controllers/users/omniauth_controller_spec.rb
@@ -28,7 +28,7 @@ describe Users::OmniauthController do
         get :callback
 
         expect(user.reload.uuid).to eq(uuid)
-        expect(response).to redirect_to(service_providers_url)
+        expect(response).to redirect_to(teams_url)
       end
 
       it 'updates the UUID to match Login.gov' do
@@ -37,7 +37,7 @@ describe Users::OmniauthController do
         get :callback
 
         expect(user.reload.uuid).to eq(uuid)
-        expect(response).to redirect_to(service_providers_url)
+        expect(response).to redirect_to(teams_url)
       end
     end
 

--- a/spec/policies/team_policy_spec.rb
+++ b/spec/policies/team_policy_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe TeamPolicy do
   let(:admin_user) { build(:user, admin: true) }
   let(:team_user) { build(:user) }
+  let(:whitelist_user) { build(:user, email: 'user@example.gov') }
   let(:other_user) { build(:user) }
   let(:team)      { build(:team) }
 
@@ -11,8 +12,10 @@ describe TeamPolicy do
   end
 
   permissions :create? do
-    it 'allows admin users to create' do
-      expect(TeamPolicy).to permit(admin_user, team)
+    it 'allows admin user or whitelisted user to create' do
+      expect(TeamPolicy).to permit(admin_user)
+      expect(TeamPolicy).to permit(whitelist_user)
+      expect(TeamPolicy).to_not permit(other_user)
     end
   end
 
@@ -33,17 +36,17 @@ describe TeamPolicy do
   end
 
   permissions :new? do
-    it 'allows admin user to initiate' do
-      expect(TeamPolicy).to permit(admin_user, team)
-      expect(TeamPolicy).to_not permit(team_user, team)
-      expect(TeamPolicy).to_not permit(other_user, team)
+    it 'allows admin user or whitelisted user to initiate' do
+      expect(TeamPolicy).to permit(admin_user)
+      expect(TeamPolicy).to permit(whitelist_user)
+      expect(TeamPolicy).to_not permit(other_user)
     end
   end
 
   permissions :destroy? do
-    it 'allows admin to destroy' do
+    it 'allows team member or admin to destroy' do
       expect(TeamPolicy).to permit(admin_user, team)
-      expect(TeamPolicy).to_not permit(team_user, team)
+      expect(TeamPolicy).to permit(team_user, team)
       expect(TeamPolicy).to_not permit(other_user, team)
     end
   end

--- a/yarn.lock
+++ b/yarn.lock
@@ -3321,7 +3321,7 @@ icss-utils@^4.0.0, icss-utils@^4.1.1:
   dependencies:
     postcss "^7.0.14"
 
-identity-style-guide@^2.1.3:
+identity-style-guide@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/identity-style-guide/-/identity-style-guide-2.2.2.tgz#30624afaeaeb62e01622e361b3a5e76fe4cc22c4"
   integrity sha512-QOmJK3FjbkFQ9cDcKZfhgG47Qr/F3Zc31YCr8A6/13fKvqMl0AhypnE2XElMoV0Qau2CLU50fN/FeD5Jdn2SVA==


### PR DESCRIPTION
**Why:** Certain users whose emails end in .gov, .mil, or .fed.us are allowed to create teams so they can get started on the dashboard right away.

Also some updates were made (even for non-whitelisted users) to fit these permissions... in particular regarding the deletion of a team:

https://docs.google.com/document/d/17gh18BoeJ84ZZKX_z78xuDGHk4Lko9AfcvtctOqT-y4/edit#