### PR TITLE
LG-2770 only admins can delete teams

### DIFF
--- a/app/helpers/team_helper.rb
+++ b/app/helpers/team_helper.rb
@@ -10,8 +10,8 @@ module TeamHelper
     whitelisted_user? || user.admin?
   end
 
-  def can_delete_team?(user, team)
-    team.users.include?(user) || user.admin?
+  def can_delete_team?(user)
+    user.admin?
   end
 
   def whitelisted_user?

--- a/app/policies/team_policy.rb
+++ b/app/policies/team_policy.rb
@@ -25,7 +25,7 @@ class TeamPolicy < BasePolicy
   end
 
   def destroy?
-    in_team? || admin?
+    admin?
   end
 
   def create?

--- a/app/views/teams/_teams_list.html.erb
+++ b/app/views/teams/_teams_list.html.erb
@@ -36,7 +36,7 @@
       </div>
       <div class='mobile-lg:grid-col-2 text-right'>
         <%= link_to 'Edit', edit_team_path(team), class: 'usa-button usa-button--outline display-block margin-bottom-1' %>
-        <% if can_delete_team?(current_user, team) %>
+        <% if can_delete_team?(current_user) %>
           <%=
             link_to(
               'Delete',

--- a/spec/policies/team_policy_spec.rb
+++ b/spec/policies/team_policy_spec.rb
@@ -44,9 +44,9 @@ describe TeamPolicy do
   end
 
   permissions :destroy? do
-    it 'allows team member or admin to destroy' do
+    it 'allows only admin to destroy' do
       expect(TeamPolicy).to permit(admin_user, team)
-      expect(TeamPolicy).to permit(team_user, team)
+      expect(TeamPolicy).to_not permit(team_user, team)
       expect(TeamPolicy).to_not permit(other_user, team)
     end
   end


### PR DESCRIPTION
**Why?** Because we don't want non-admins to accidentally delete teams