### PR TITLE
Change the port that webpack-dev-server uses from the default

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -59,7 +59,7 @@ development:
   dev_server:
     https: false
     host: localhost
-    port: 3035
+    port: 3036
     public: localhost:3035
     hmr: false
     # Inline should be set to true if using HMR


### PR DESCRIPTION
**Why**: This app and the IdP try to listen to the dev server on the same port. This causes lots of funny stuff to happen with the assets. Bumping the port the dashboard uses up 1 fixes this.