### PR TITLE
Fix the dev server port in more places

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -5,25 +5,25 @@ SecureHeaders::Configuration.default do |config|
   config.x_xss_protection = '1; mode=block'
   config.x_download_options = 'noopen'
   config.x_permitted_cross_domain_policies = 'none'
-  form_action =  %w[self *.identitysandbox.gov]
+  form_action =  ["'self'", '*.identitysandbox.gov']
   form_action << %w[localhost:3000] if Rails.env.development?
-  connect_src = %w[self]
+  connect_src = ["'self'"]
   connect_src << %w[ws://localhost:3036 http://localhost:3036] if Rails.env.development?
   config.csp = {
-    default_src: %w[self],
-    frame_src: %w[self], # deprecated in CSP 2.0
-    child_src: %w[self], # CSP 2.0 only; replaces frame_src
+    default_src: ["'self'"],
+    frame_src: ["'self'"], # deprecated in CSP 2.0
+    child_src: ["'self'"], # CSP 2.0 only; replaces frame_src
     # frame_ancestors: %w('self'), # CSP 2.0 only; overriden by x_frame_options in some browsers
     form_action: form_action.flatten,
     block_all_mixed_content: true, # CSP 2.0 only;
     connect_src: connect_src.flatten,
-    font_src: %w[self data:],
-    img_src: %w[self data:],
-    media_src: %w[self],
-    object_src: %w[none],
-    script_src: %w[self *.newrelic.com *.nr-data.net],
-    style_src: %w[self],
-    base_uri: %w[self],
+    font_src: ["'self'", 'data:'],
+    img_src: ["'self'", 'data:'],
+    media_src: ["'self'"],
+    object_src: ["'none'"],
+    script_src: ["'self'", '*.newrelic.com', '*.nr-data.net'],
+    style_src: ["'self'"],
+    base_uri: ["'self'"],
   }
   # Temporarily disabled until we configure pinning. See GitHub issue #1895.
   # config.hpkp = {

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -5,25 +5,25 @@ SecureHeaders::Configuration.default do |config|
   config.x_xss_protection = '1; mode=block'
   config.x_download_options = 'noopen'
   config.x_permitted_cross_domain_policies = 'none'
-  form_action =  %w['self' *.identitysandbox.gov]
+  form_action =  %w[self *.identitysandbox.gov]
   form_action << %w[localhost:3000] if Rails.env.development?
-  connect_src = %w['self']
-  connect_src << %w[ws://localhost:3035 http://localhost:3035] if Rails.env.development?
+  connect_src = %w[self]
+  connect_src << %w[ws://localhost:3036 http://localhost:3036] if Rails.env.development?
   config.csp = {
-    default_src: %w['self'],
-    frame_src: %w['self'], # deprecated in CSP 2.0
-    child_src: %w['self'], # CSP 2.0 only; replaces frame_src
+    default_src: %w[self],
+    frame_src: %w[self], # deprecated in CSP 2.0
+    child_src: %w[self], # CSP 2.0 only; replaces frame_src
     # frame_ancestors: %w('self'), # CSP 2.0 only; overriden by x_frame_options in some browsers
     form_action: form_action.flatten,
     block_all_mixed_content: true, # CSP 2.0 only;
     connect_src: connect_src.flatten,
-    font_src: %w['self' data:],
-    img_src: %w['self' data:],
-    media_src: %w['self'],
-    object_src: %w['none'],
-    script_src: %w['self' *.newrelic.com *.nr-data.net],
-    style_src: %w['self'],
-    base_uri: %w['self'],
+    font_src: %w[self data:],
+    img_src: %w[self data:],
+    media_src: %w[self],
+    object_src: %w[none],
+    script_src: %w[self *.newrelic.com *.nr-data.net],
+    style_src: %w[self],
+    base_uri: %w[self],
   }
   # Temporarily disabled until we configure pinning. See GitHub issue #1895.
   # config.hpkp = {

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -60,7 +60,7 @@ development:
     https: false
     host: localhost
     port: 3036
-    public: localhost:3035
+    public: localhost:3036
     hmr: false
     # Inline should be set to true if using HMR
     inline: true


### PR DESCRIPTION
**Why**: We changed the webpack dev server to use port 3036 so it doesn't collide with the IdP. This commit updates that port in a few places I missed.