### PR TITLE
LG-2788 Upgrade to latest style guide with button fixes

### DIFF
--- a/app/assets/stylesheets/application.css.scss.erb
+++ b/app/assets/stylesheets/application.css.scss.erb
@@ -31,14 +31,3 @@ $image-path: 'img';
   margin-top: 1.5rem;
   padding: 9px 20px;
 }
-
-.button-delete {
-  color: white !important;
-  text-decoration: none !important;
-}
-
-.button-secondary {
-  color: #0071bc !important;
-  text-decoration: none !important;
-}
-

--- a/app/views/emails/index.html.erb
+++ b/app/views/emails/index.html.erb
@@ -1,6 +1,6 @@
 <div class="usa-display">Emails</div>
 
-<table class="usa-table-borderless">
+<table class="usa-table">
   <thead>
     <tr>
       <th scope="col">Email</th>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -149,7 +149,7 @@
 
     <main class="usa-layout-docs usa-section" id="main-content">
       <div class="grid-container">
-        <div class="usa-layout-docs-main_content usa-prose">
+        <div class="usa-layout-docs-main_content">
           <%= render 'layouts/messages' %>
           <%= yield %>
         </div>

--- a/app/views/service_providers/all.html.erb
+++ b/app/views/service_providers/all.html.erb
@@ -4,7 +4,7 @@
 <%= button_to t('forms.buttons.trigger_idp_refresh'), api_service_providers_path, method: :post, :class => "usa-button" %>
 
 
-<table class="usa-table-borderless">
+<table class="usa-table">
   <thead>
     <tr>
       <th scope="col">Friendly name</th>

--- a/app/views/service_providers/index.html.erb
+++ b/app/views/service_providers/index.html.erb
@@ -1,9 +1,8 @@
-
 <div class="usa-display">My apps</div>
 
 <%= button_to t('headings.service_providers.new_app'), new_service_provider_path, method: :get, :class => "usa-button" %>
 
-<table class="usa-table-borderless">
+<table class="usa-table">
   <thead>
     <tr>
       <th scope="col">Friendly name</th>

--- a/app/views/teams/edit.html.erb
+++ b/app/views/teams/edit.html.erb
@@ -11,7 +11,7 @@
             team_path(@team),
             method: :delete,
             data: { confirm: 'Are you sure you want to delete this team?' },
-            class: 'usa-button usa-button--danger float-left button-delete',
+            class: 'usa-button usa-button--danger float-left',
             )
     %>
   <% end %>
@@ -19,5 +19,5 @@
   <%= form.button :submit, 'Update', class: "usa-button float-left" %>
 
   <%= link_to t('forms.buttons.cancel'), teams_path,
-                class: 'usa-button usa-button--outline float-left button-secondary', method: :get %>
+                class: 'usa-button usa-button--outline float-left', method: :get %>
 <% end %>

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -1,4 +1,4 @@
-<h1 class='margin-bottom-2'>My teams</h1>
+<div class="usa-display">My teams</div>
 
 <div>
   <% if @teams.count > 0 %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -3,7 +3,7 @@
 
  	<%= button_to t('headings.users.new_user'), new_user_path, method: :get, :class => "usa-button" %>
 
-<table class="usa-table-borderless">
+<table class="usa-table">
   <thead>
     <tr>
       <th scope="col">Email</th>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "@rails/webpacker": "^4.2.0",
-    "identity-style-guide": "^2.2.2",
+    "identity-style-guide": "^2.2.3",
     "jquery": "^3.4.1",
     "jquery-ujs": "^1.2.2",
     "serialize-javascript": "^2.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3321,10 +3321,10 @@ icss-utils@^4.0.0, icss-utils@^4.1.1:
   dependencies:
     postcss "^7.0.14"
 
-identity-style-guide@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/identity-style-guide/-/identity-style-guide-2.2.2.tgz#30624afaeaeb62e01622e361b3a5e76fe4cc22c4"
-  integrity sha512-QOmJK3FjbkFQ9cDcKZfhgG47Qr/F3Zc31YCr8A6/13fKvqMl0AhypnE2XElMoV0Qau2CLU50fN/FeD5Jdn2SVA==
+identity-style-guide@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/identity-style-guide/-/identity-style-guide-2.2.3.tgz#e6d6b6b10a65d0e97877d35e5e00f3850ed23a62"
+  integrity sha512-bAPgCic/ztIUOLyEofToecfhIiM8b1WNlRj0rOhYr1/zZHL4NPhLjQ2HBURTiGyxEhm/22n1gxprDuilxLLLBw==
   dependencies:
     zxcvbn "^4.4.2"
 


### PR DESCRIPTION
**Why:** Because we were forcing button styles on our buttons since the design system was overriding them with form link styles. Since we updated the design system, we are removing the custom styles from the dashboard.

Also I removed the overarching `usa-prose` class after discovering it can clash with some non-usa-prose styles, and it was being applied to pages which are not comprised of longform text (which is what usa-prose is intended for https://design.login.gov/typography/ )