### PR TITLE
Add explicit require to fix undefined constant SMTP_SETTINGS

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,6 +69,7 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   config.action_mailer.delivery_method = :smtp
+  require_relative '../smtp.rb'
   config.action_mailer.smtp_settings = SMTP_SETTINGS
   config.action_mailer.default_url_options = {
     host: Figaro.env.mailer_domain,


### PR DESCRIPTION
We see this error when deploying the dashboard

```
NameError: uninitialized constant SMTP_SETTINGS
/srv/dashboard/releases/20200318230821/config/environments/production.rb:72:in `block in <top (required)>'
```

My suspicion is that it's got something to do with the Rails 5.2 upgrade, but this is a minimal patch that will let us continue to deploy the dashboard (verified by patching on a box)


