### PR TITLE
Don't use the amazon adapter for active storage if logo upload is disabled

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,11 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :amazon
+  config.active_storage.service = if Figaro.env.logo_upload_enabled == 'true'
+                                    :amazon
+                                  else
+                                    :local
+                                  end
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true


### PR DESCRIPTION
**Why**: Because if local storage is disabled the configs for the Amazon adapter most likely are not present