### PR TITLE
LG-2795 Create separate team card views for admins and partners

### DIFF
--- a/app/views/teams/_teams_list.html.erb
+++ b/app/views/teams/_teams_list.html.erb
@@ -26,11 +26,11 @@
         <p class='margin-y-2'>
           <strong>
             <%= 'User'.pluralize(team.users.count) %>
-            <%= "[#{team.users.count}]:" if team.users.count > 1 %>
+            <%= "[#{team.users.count}]" if team.users.count > 1 %><%= ":" if team.users.count > 1 && current_user.admin? %>
           </strong>
           <br/>
-          <% team.users.each do |user| %>
-            <%= user.email %>
+          <% if current_user.admin? %>
+            <%= team.users.map{ |user| link_to(user.email, edit_user_path(user.id), class:'text-primary text-no-underline' ) }.join(", ").html_safe %>
           <% end %>
         </p>
       </div>

--- a/app/views/teams/edit.html.erb
+++ b/app/views/teams/edit.html.erb
@@ -19,5 +19,5 @@
   <%= form.button :submit, 'Update', class: "usa-button float-left" %>
 
   <%= link_to t('forms.buttons.cancel'), teams_path,
-                class: 'usa-button usa-button--outline float-left', method: :get %>
+                class: 'usa-button usa-button--outline float-left' %>
 <% end %>


### PR DESCRIPTION
**Why:**  We want admins to see links to team members' profiles in the teams card, and we want partners to only see a team member count on the card.

 