### PR TITLE
LG-2813 Improve admin landing page, and other improvements

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,11 +3,7 @@ class HomeController < ApplicationController
     render :index and return unless user_signed_in?
 
     includes = %i[users service_providers agency]
-    @teams = if current_user.admin?
-               Team.includes(*includes).all
-             else
-               current_user.teams.includes(*includes).all
-             end
+    @teams = current_user.teams.includes(*includes).all
 
     render 'home/authenticated/index'
   end

--- a/app/controllers/service_providers_controller.rb
+++ b/app/controllers/service_providers_controller.rb
@@ -1,7 +1,7 @@
 # rubocop:disable Metrics/ClassLength
 # :reek:InstanceVariableAssumption
 class ServiceProvidersController < AuthenticatedController
-  before_action :authorize_service_provider, only: %i[update edit show destroy]
+  before_action :authorize_service_provider
   before_action :authorize_approval, only: [:update]
 
   def index; end
@@ -44,7 +44,8 @@ class ServiceProvidersController < AuthenticatedController
   private
 
   def authorize_service_provider
-    authorize service_provider
+    authorize service_provider if %i[update edit show destroy].include?(action_name.to_sym)
+    authorize ServiceProvider if action_name == 'all'
   end
 
   def service_provider

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,6 +1,6 @@
 # :reek:InstanceVariableAssumption
 class TeamsController < AuthenticatedController
-  before_action -> { authorize Team }, only: %i[index create new]
+  before_action -> { authorize Team }, only: %i[index create new all]
   before_action -> { authorize team }, only: %i[edit update destroy show]
 
   def new
@@ -43,11 +43,14 @@ class TeamsController < AuthenticatedController
 
   def index
     includes = %i[users service_providers agency]
-    @teams = if current_user.admin?
-               Team.includes(*includes).all
-             else
-               current_user.teams.includes(*includes).all
-             end
+    @teams = current_user.teams.includes(*includes).all
+  end
+
+  def all
+    includes = %i[users service_providers agency]
+    @teams = Team.includes(*includes).all
+
+    render 'teams/all'
   end
 
   def show; end

--- a/app/helpers/service_provider_helper.rb
+++ b/app/helpers/service_provider_helper.rb
@@ -74,6 +74,8 @@ module ServiceProviderHelper
     sp_json.map do |config_key, value|
       if %w[agency_id default_help_text help_text attribute_bundle redirect_uris].include?(config_key)
         [config_key, value]
+      elsif config_key == 'saml_client_cert'
+        ['cert', value]
       else
         [config_key, "'#{value}'"]
       end

--- a/app/policies/service_provider_policy.rb
+++ b/app/policies/service_provider_policy.rb
@@ -34,6 +34,10 @@ class ServiceProviderPolicy < BasePolicy
     true
   end
 
+  def all?
+    admin?
+  end
+
   private
 
   def owner?

--- a/app/policies/team_policy.rb
+++ b/app/policies/team_policy.rb
@@ -36,6 +36,10 @@ class TeamPolicy < BasePolicy
     whitelisted_user? || admin?
   end
 
+  def all?
+    admin?
+  end
+
   private
 
   def admin?

--- a/app/views/home/authenticated/index.html.erb
+++ b/app/views/home/authenticated/index.html.erb
@@ -1,4 +1,4 @@
-<% if can_create_teams?(current_user) %>
+<% if whitelisted_user? %>
   <div class="usa-alert usa-alert--info">
     <div class="usa-alert__body">
       <p class="usa-alert__text">You can now create teams.</p>
@@ -7,7 +7,11 @@
 <% end %>
 
 <h1 class="usa-display">Hello</h1>
-<p class='usa-intro'>Let's integrate apps with login.gov</p>
+<% if whitelisted_user? %>
+  <p class='usa-intro'>Let's integrate apps with login.gov</p>
+<% elsif current_user.admin? %>
+  <p class='usa-intro'>Let's help our Partners integrate apps with login.gov</p>
+<% end %>
 
 <% if @teams.count > 0 %>
   <%=
@@ -16,7 +20,7 @@
         new_team_path,
         method: :get,
         class: "usa-button margin-top-4 margin-bottom-4",
-        ) if can_create_teams? (current_user)
+        ) if whitelisted_user?
   %>
 <% end %>
 <h1 class='margin-bottom-3'>My teams</h1>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -102,6 +102,11 @@
                   <span>Apps</span>
                 </a>
               </li>
+              <li class="usa-nav__primary-item">
+                <a class="usa-nav__link" href="<%= teams_path %>">
+                  <span>Teams</span>
+                </a>
+              </li>
               <% if current_user.admin? %>
                 <li class="usa-nav__primary-item">
                   <button class="usa-accordion__button usa-nav__link" aria-controls="unique-id-1">
@@ -109,24 +114,18 @@
                   </button>
                   <ul id="unique-id-1" class="usa-nav__submenu">
                     <li class="usa-nav__submenu-item">
-                      <a href="/service_providers/all">Apps</a>
+                      <a href="<%= service_providers_all_path %>">All apps</a>
                     </li>
                     <li class="usa-nav__submenu-item">
-                      <a href="/users">Users</a>
+                      <a href="<%= users_path %>">Users</a>
                     </li>
                     <li class="usa-nav__submenu-item">
-                      <a href="/teams">Teams</a>
+                      <a href=<%= teams_all_path %>>All teams</a>
                     </li>
                     <li class="usa-nav__submenu-item">
-                      <a href="/emails">Emails</a>
+                      <a href="<%= emails_path %>">Emails</a>
                     </li>
                   </ul>
-                </li>
-              <% else %>
-                <li class="usa-nav__primary-item">
-                  <a class="usa-nav__link" href="<%= teams_path %>">
-                    <span>Teams</span>
-                  </a>
                 </li>
               <% end %>
               <li class="usa-nav__primary-item">

--- a/app/views/teams/_teams_list.html.erb
+++ b/app/views/teams/_teams_list.html.erb
@@ -14,13 +14,11 @@
         <p class='margin-y-2'>
           <strong>
             <%= 'App'.pluralize(team.service_providers.count) %>
-            <%= "[#{team.service_providers.count}]:" if team.service_providers.count > 1 %>
+            <%= "[#{team.service_providers.count}]:" %>
           </strong>
           <br/>
           <% team.service_providers.each do |service_provider| %>
-            <span class='usa-tag bg-primary-lighter text-bold margin-right-1 padding-x-1 padding-y-05 text-no-wrap'>
-              <%= link_to service_provider.friendly_name, service_provider, class: 'text-primary text-no-underline' %>
-            </span>
+            <%= link_to service_provider.friendly_name, service_provider, class: "usa-button usa-button--inverse usa-button--tiny margin-top-1" %>
           <% end %>
         </p>
         <p class='margin-y-2'>

--- a/app/views/teams/all.html.erb
+++ b/app/views/teams/all.html.erb
@@ -1,0 +1,31 @@
+<div class="usa-display">All teams</div>
+
+<div>
+  <% if @teams.count > 0 %>
+    <%=
+      button_to(
+          t('headings.teams.new_team'),
+          new_team_path,
+          method: :get,
+          class: "usa-button margin-top-4 margin-bottom-4",
+          ) if can_create_teams? (current_user)
+    %>
+    <%= render 'teams_list' %>
+  <% elsif can_create_teams?(current_user) %>
+    <div class='lg-card'>
+      <div class='grid-row flex-row flex-align-end'>
+        <div class='mobile-lg:grid-col-10'>
+          <h1 class='margin-bottom-05'>Create your first team</h1>
+          <p class='margin-top-05'>Get started with the sandbox environment. Make a team for your integration project.</p>
+        </div>
+          <div class='mobile-lg:grid-col-2 text-right'>
+          <a href="<%= new_team_path %>" class='usa-button usa-button--outline'>Continue</a>
+        </div>
+      </div>
+    </div>
+  <% else %>
+    <p>
+      You aren't a part of any teams yet.
+    </p>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
   get '/env' => 'env#index'
 
   resources :users
+
+  get '/teams/all' => 'teams#all'
   resources :teams
 
   get '/emails' => 'emails#index'

--- a/spec/features/teams_spec.rb
+++ b/spec/features/teams_spec.rb
@@ -56,7 +56,7 @@ feature 'User teams CRUD' do
     create(:agency, name: 'USDS')
     login_as(admin)
 
-    visit teams_path
+    visit teams_all_path
     find("a[href='#{edit_team_path(org)}']").click
     expect(current_path).to eq(edit_team_path(org))
 
@@ -82,7 +82,7 @@ feature 'User teams CRUD' do
     sp = create(:service_provider, team: team)
 
     login_as(admin)
-    visit teams_path
+    visit teams_all_path
 
     expect(page).to have_content(org1.name)
     expect(page).to have_content(org2.name)
@@ -101,7 +101,7 @@ feature 'User teams CRUD' do
       create(:service_provider, team: team)
 
       login_as(admin)
-      visit teams_path
+      visit teams_all_path
       find("a[href='#{team_path(team)}']", text: team.name).click
 
       expect(current_path).to eq(team_path(team))
@@ -129,7 +129,7 @@ feature 'User teams CRUD' do
     team = create(:team)
     login_as(admin)
 
-    visit teams_path
+    visit teams_all_path
     find("a[href='#{edit_team_path(team)}']").click
     find("a[href='#{team_path(team)}']", text: 'Delete').click
 

--- a/spec/helpers/service_provider_helper_spec.rb
+++ b/spec/helpers/service_provider_helper_spec.rb
@@ -77,6 +77,7 @@ describe ServiceProviderHelper do
         group_id
         identity_protocol
         production_issuer
+        saml_client_cert
       ]
     end
     it 'returns the sp issuer in the yaml blurb' do


### PR DESCRIPTION
**Why?**  We want admins to have an easy-to-read landing page on the dashboard that only includes the teams of which they are members, rather than all Partnership teams on the landing page.

Snuck some other things into this PR:

- Make separate pages for an admin user's teams and an admin-only view of "All teams" ([LG-2815](https://cm-jira.usa.gov/browse/LG-2815))
       - Restricted access for 'all' pages to admins only (like the new `/teams/all`, and `/service_providers/all`, which was accessible by any partner before)

- Updated buttons for apps on team cards ([LG-2814](https://cm-jira.usa.gov/browse/LG-2814))
- Allow "0" label to show when there are no apps on a team card ([LG-2817](https://cm-jira.usa.gov/browse/LG-2817))
- Quick fix to admin SP yaml blurb ('cert' key is correct) ([LG-2696](https://cm-jira.usa.gov/browse/LG-2696))
