### PR TITLE
LG-2863 Add generic agency option

### DIFF
--- a/config/agencies.yml
+++ b/config/agencies.yml
@@ -36,3 +36,5 @@
   name: 'NLRB'
 19:
   name: 'HHS'
+20:
+  name: 'State, local governments or tribes'

--- a/config/agencies.yml
+++ b/config/agencies.yml
@@ -37,4 +37,6 @@
 19:
   name: 'HHS'
 20:
+  name: "LOC"
+21:
   name: 'State, local governments or tribes'


### PR DESCRIPTION
**Why:** Because we want state/local/tribe users to be able to select a generic agency when creating a team. 