### PR TITLE
LG-2882 prompt user to delete apps before deleting non-empty team

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -37,11 +37,11 @@ class TeamsController < AuthenticatedController
   def destroy
     if @team.service_providers.empty? && @team.destroy
       flash[:success] = 'Success'
-      redirect_to teams_path and return
+      return redirect_to teams_path
     end
 
     flash[:warning] = I18n.t('notices.team_delete_failed')
-    redirect_back(fallback_location: teams_path) and return
+    redirect_back(fallback_location: teams_path)
   end
 
   def index

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -35,9 +35,13 @@ class TeamsController < AuthenticatedController
   end
 
   def destroy
-    return unless @team.destroy
-    flash[:success] = 'Success'
-    redirect_to teams_path
+    if @team.service_providers.empty? && @team.destroy
+      flash[:success] = 'Success'
+      redirect_to teams_path and return
+    end
+
+    flash[:warning] = I18n.t('notices.team_delete_failed')
+    redirect_back(fallback_location: teams_path) and return
   end
 
   def index

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,7 @@ en:
     service_providers_refresh_failed: Failed to publish service providers. Email partners@login.gov for support.
     service_providers_refreshed: Success! Service providers publish request has been sent.
     user_deleted: Success! You have deleted %{email}
+    team_delete_failed: Only teams without apps can be deleted. Reassign or delete the apps first.
   omniauth:
     logout_fail: Logout failed
     logout_ok: Successfully logged out

--- a/spec/features/teams_spec.rb
+++ b/spec/features/teams_spec.rb
@@ -137,4 +137,18 @@ feature 'User teams CRUD' do
     expect(page).to have_content('Success')
     expect(page).to_not have_content(team.name)
   end
+
+  scenario 'Delete when a team still has service providers' do
+    admin = create(:admin)
+    team = create(:team)
+    create(:service_provider, team: team)
+
+    login_as(admin)
+
+    visit edit_team_path(team)
+    find("a[href='#{team_path(team)}']", text: 'Delete').click
+
+    expect(current_path).to eq(edit_team_path(team))
+    expect(page).to have_content(I18n.t('notices.team_delete_failed'))
+  end
 end


### PR DESCRIPTION
**Why:** Because we don't want to delete teams which still have apps attached to them, therefore orphaning those apps. 