### PR TITLE
LG-2511 changing color of label text to be different from input text on forms

### DIFF
--- a/app/assets/stylesheets/application.css.scss.erb
+++ b/app/assets/stylesheets/application.css.scss.erb
@@ -27,3 +27,7 @@ $image-path: 'img';
   margin-top: 1.5rem;
   padding: 9px 20px;
 }
+
+.usa-label {
+  color: map-get($site-palette, 'site-dark-grey');
+}


### PR DESCRIPTION
Why? so the text on new/edit team and new/edit app for labels and values are different