### PR TITLE
LG-2816 Change log in/logout to sign in/sign out

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -130,7 +130,7 @@
               <% end %>
               <li class="usa-nav__primary-item">
                 <a class="usa-nav__link" href="<%= destroy_user_session_path %>">
-                  <span>Logout</span>
+                  <span><%= t('links.sign_out') %></span>
                 </a>
               </li>
               <% else %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,7 +48,7 @@ en:
     edit: Edit
     pending_changes: pending changes
     service_providers: My service providers
-    sign_in: Log in
+    sign_in: Sign in
     sign_out: Sign out
     teams: Manage user teams
     users: Manage users


### PR DESCRIPTION
**Why:** Because we want partners to see sign in/sign out buttons that will be consistent with new partners site sign in button.