### PR TITLE
LG-2871: have logo uploads enabled by default

### DIFF
--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -75,7 +75,7 @@
                    input_html: { class: 'usa-input' } %>
   <% end %>
 
-  <% if Figaro.env.logo_upload_enabled == 'true' %>
+  <% if ENV.fetch('logo_upload_enabled', 'true') == 'true' %>
     <%= render 'logo_upload', form: form, service_provider: service_provider %>
   <% else %>
     <%= form.input :logo,

--- a/app/views/service_providers/show.html.erb
+++ b/app/views/service_providers/show.html.erb
@@ -29,7 +29,7 @@
       <p class="font-mono-xs margin-top-0" name="production_issuer"><%=  service_provider.production_issuer %></p>
     <% end %>
 
-<% if Figaro.env.logo_upload_enabled == 'true' %>
+<% if ENV.fetch('logo_upload_enabled') { 'true' } == 'true' %>
   <h4><label for="logo_file">Uploaded Logo:</label></h4>
   <% if service_provider.logo_file.attached? %>
     <p class="font-mono-xs margin-top-0" name="logo_file">

--- a/app/views/service_providers/show.html.erb
+++ b/app/views/service_providers/show.html.erb
@@ -29,7 +29,7 @@
       <p class="font-mono-xs margin-top-0" name="production_issuer"><%=  service_provider.production_issuer %></p>
     <% end %>
 
-<% if ENV.fetch('logo_upload_enabled') { 'true' } == 'true' %>
+<% if ENV.fetch('logo_upload_enabled', 'true') == 'true' %>
   <h4><label for="logo_file">Uploaded Logo:</label></h4>
   <% if service_provider.logo_file.attached? %>
     <p class="font-mono-xs margin-top-0" name="logo_file">

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -4,7 +4,7 @@ test: &default
   certificate_expiration_warning_period: '60'
   dashboard_api_token: 'sekret'
   idp_sp_url: 'http://idp.example.com/api/service_provider'
-  # logo_upload_enabled: 'false' # uncomment to change the hardcoded default
+  logo_upload_enabled: 'false'
   mailer_domain: 'https://dashboard.login.gov'
   newrelic_license_key: ''
   saml_sp_certificate: |
@@ -106,6 +106,7 @@ development:
   <<: *default
   dashboard_api_token: 'test_token'
   idp_sp_url: 'http://localhost:3000/api/service_provider'
+  # logo_upload_enabled: 'false' # uncomment to change the hardcoded default
 
 # The entire application.yml is overwritten in production, so don't set
 # anything here.

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -1,10 +1,10 @@
 test: &default
   aws_region: us-west-2
-  aws_logo_bucket: 'changeme'
+  # aws_logo_bucket: 'changeme'
   certificate_expiration_warning_period: '60'
   dashboard_api_token: 'sekret'
   idp_sp_url: 'http://idp.example.com/api/service_provider'
-  logo_upload_enabled: 'true'
+  # logo_upload_enabled: 'true'
   mailer_domain: 'https://dashboard.login.gov'
   newrelic_license_key: ''
   saml_sp_certificate: |

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -1,10 +1,10 @@
 test: &default
   aws_region: us-west-2
-  # aws_logo_bucket: 'changeme'
+  # aws_logo_bucket: 'changeme' # uncomment to change the hardcoded default
   certificate_expiration_warning_period: '60'
   dashboard_api_token: 'sekret'
   idp_sp_url: 'http://idp.example.com/api/service_provider'
-  # logo_upload_enabled: 'true'
+  # logo_upload_enabled: 'false' # uncomment to change the hardcoded default
   mailer_domain: 'https://dashboard.login.gov'
   newrelic_license_key: ''
   saml_sp_certificate: |

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,7 +29,12 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :local
+  logo_enabled = ENV.fetch('logo_upload_enabled') { 'true' } == 'true'
+  config.active_storage.service = if logo_enabled
+                                    :amazon
+                                  else
+                                    :local
+                                  end
   # Allow SVG's only because we will always serve them in an <img> element
   config.active_storage.content_types_to_serve_as_binary -= ['image/svg+xml']
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,12 +29,8 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  logo_enabled = ENV.fetch('logo_upload_enabled') { 'true' } == 'true'
-  config.active_storage.service = if logo_enabled
-                                    :amazon
-                                  else
-                                    :local
-                                  end
+  logo_enabled = ENV.fetch('logo_upload_enabled', 'true') == 'true'
+  config.active_storage.service = logo_enabled ? :amazon : :local
   # Allow SVG's only because we will always serve them in an <img> element
   config.active_storage.content_types_to_serve_as_binary -= ['image/svg+xml']
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,8 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = if Figaro.env.logo_upload_enabled == 'true'
+  logo_enabled = ENV.fetch('logo_upload_enabled') { 'true' } == 'true'
+  config.active_storage.service = if logo_enabled
                                     :amazon
                                   else
                                     :local

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,12 +47,8 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  logo_enabled = ENV.fetch('logo_upload_enabled') { 'true' } == 'true'
-  config.active_storage.service = if logo_enabled
-                                    :amazon
-                                  else
-                                    :local
-                                  end
+  logo_enabled = ENV.fetch('logo_upload_enabled', 'true') == 'true'
+  config.active_storage.service = logo_enabled ? :amazon : :local
   # Allow SVG's only because we will always serve them in an <img> element
   config.active_storage.content_types_to_serve_as_binary -= ['image/svg+xml']
 

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -8,7 +8,7 @@ local:
 
 amazon:
   service: S3
-  region: <%= Figaro.env.aws_region %>
-  bucket: <%= Figaro.env.aws_logo_bucket %>
+  region: <%= ENV.fetch('aws_region') { 'us-west-2' } %>
+  bucket: <%= ENV.fetch('aws_logo_bucket') { 'login-gov-partner-logos-int.894947205914-us-west-2' } %>
   upload:
     acl: 'public-read'

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -8,7 +8,7 @@ local:
 
 amazon:
   service: S3
-  region: <%= ENV.fetch('aws_region') { 'us-west-2' } %>
-  bucket: <%= ENV.fetch('aws_logo_bucket') { 'login-gov-partner-logos-int.894947205914-us-west-2' } %>
+  region: <%= ENV.fetch('aws_region', 'us-west-2') %>
+  bucket: <%= ENV.fetch('aws_logo_bucket', 'login-gov-partner-logos-int.894947205914-us-west-2') %>
   upload:
     acl: 'public-read'

--- a/spec/features/logo_upload_spec.rb
+++ b/spec/features/logo_upload_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 feature 'Logo upload' do
   let(:user) { create(:user, :with_teams) }
 
+  before do
+    ENV['logo_upload_enabled'] = 'true'
+  end
+
   context 'on create' do
     before do
       login_as(user)


### PR DESCRIPTION
Given the difficulty in sorting out how to actually push out changes to figaro settings without a devops PR, we're going to simply turn on logo uploads by default. They may still be turned off via figaro, and the bucket is still configurable via figaro.

If I can get this merged asap, I'll test out in `dev` prior to it getting auto deployed to `int`.