### PR TITLE
LG-2954: stop logging to STDOUT in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,7 @@ end
 
 group :production do
   gem 'rack-timeout'
-  gem 'rails_12factor'
+  gem 'rails_serve_static_assets'
 end
 
 gem 'autoprefixer-rails', '~> 9.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -329,11 +329,7 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
     rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (5.2.4.2)
       actionpack (= 5.2.4.2)
       activesupport (= 5.2.4.2)
@@ -536,7 +532,7 @@ DEPENDENCIES
   rack_session_access
   rails (~> 5.2.0)
   rails-controller-testing (>= 1.0.2)
-  rails_12factor
+  rails_serve_static_assets
   recipient_interceptor
   responders (~> 2.4)
   rest-client (~> 2.0)


### PR DESCRIPTION
The current infrastructure design has the standard log file being streamed to AWS CloudWatch. Early on in development, the dashboard was outfitted with the `rails_12factor` gem that, among other things, pulls in the `rails_stdout_logging` gem and forces the Rails logger to write to STDOUT. As such, we've had no access to the deployed dashboard logs since at least March 2018.

For now, we should back out the `rails_stdout_logger` gem and log to the default log file.