### PR TITLE
LG-2871: ready for logo uploads to go live

### DIFF
--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -75,7 +75,7 @@
                    input_html: { class: 'usa-input' } %>
   <% end %>
 
-  <% if Figaro.env.logo_upload_enabled == 'true' %>
+  <% if ENV.fetch('logo_upload_enabled', 'true') == 'true' %>
     <%= render 'logo_upload', form: form, service_provider: service_provider %>
   <% else %>
     <%= form.input :logo,

--- a/app/views/service_providers/show.html.erb
+++ b/app/views/service_providers/show.html.erb
@@ -29,7 +29,7 @@
       <p class="font-mono-xs margin-top-0" name="production_issuer"><%=  service_provider.production_issuer %></p>
     <% end %>
 
-<% if Figaro.env.logo_upload_enabled == 'true' %>
+<% if ENV.fetch('logo_upload_enabled', 'true') == 'true' %>
   <h4><label for="logo_file">Uploaded Logo:</label></h4>
   <% if service_provider.logo_file.attached? %>
     <p class="font-mono-xs margin-top-0" name="logo_file">

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -19,8 +19,12 @@ smtp_password: changeme
 smtp_username: changeme
 
 test: &default
+  aws_region: us-west-2
+  # aws_logo_bucket: 'changeme'
+  certificate_expiration_warning_period: '60'
   dashboard_api_token: 'sekret'
   idp_sp_url: 'http://idp.example.com/api/service_provider'
+  logo_upload_enabled: 'false'
   mailer_domain: 'https://dashboard.login.gov'
   saml_sp_private_key: |
     -----BEGIN RSA PRIVATE KEY-----

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,7 +29,8 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :local
+  logo_enabled = ENV.fetch('logo_upload_enabled', 'true') == 'true'
+  config.active_storage.service = logo_enabled ? :amazon : :local
   # Allow SVG's only because we will always serve them in an <img> element
   config.active_storage.content_types_to_serve_as_binary -= ['image/svg+xml']
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,11 +47,8 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = if Figaro.env.logo_upload_enabled == 'true'
-                                    :amazon
-                                  else
-                                    :local
-                                  end
+  logo_enabled = ENV.fetch('logo_upload_enabled', 'true') == 'true'
+  config.active_storage.service = logo_enabled ? :amazon : :local
   # Allow SVG's only because we will always serve them in an <img> element
   config.active_storage.content_types_to_serve_as_binary -= ['image/svg+xml']
 

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -8,7 +8,7 @@ local:
 
 amazon:
   service: S3
-  region: <%= Figaro.env.aws_region %>
-  bucket: <%= Figaro.env.aws_logo_bucket %>
+  region: <%= ENV.fetch('aws_region', 'us-west-2') %>
+  bucket: <%= ENV.fetch('aws_logo_bucket', 'login-gov-partner-logos-int.894947205914-us-west-2') %>
   upload:
     acl: 'public-read'

--- a/spec/features/logo_upload_spec.rb
+++ b/spec/features/logo_upload_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 feature 'Logo upload' do
   let(:user) { create(:user, :with_teams) }
   before do
-    allow(Figaro.env).to receive(:logo_upload_enabled).and_return('true')
+    ENV['logo_upload_enabled'] = 'true'
   end
 
   context 'on create' do

--- a/spec/features/service_providers_spec.rb
+++ b/spec/features/service_providers_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 feature 'Service Providers CRUD' do
   before do
     allow(Figaro.env).to receive(:logo_upload_enabled).and_return('false')
+    ENV['logo_upload_enabled'] = 'false'
   end
 
   context 'Regular user' do


### PR DESCRIPTION
PR #329 reverted the default enabling of logo uploads for partners. That was necessary because we didn't have a convenient way to turn off the feature, and the uploads were blocked by our body size limit of 10k (most logo files are bigger than 10k). The upload limit has been increased to 2MB, so we should be able to run with this now.