### PR TITLE
LG-2960: clean up logo upload

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -102,6 +102,9 @@ Layout/MultilineOperationIndentation:
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
+Layout/TrailingBlankLines:
+  Enabled: false
+
 Lint/PercentStringArray:
   Enabled: true
   Exclude:

--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -76,8 +76,7 @@
   <% end %>
 
   <%# Temp hack to allow feature in dev but not int for testing %>
-  <% if (ENV.fetch('logo_upload_enabled', 'true') == 'true') &&
-        (LoginGov::Hostdata.env != 'int') %>
+  <% if Figaro.env.logo_upload_enabled == 'true' %>
     <%= render 'logo_upload', form: form, service_provider: service_provider %>
   <% else %>
     <%= form.input :logo,

--- a/app/views/service_providers/show.html.erb
+++ b/app/views/service_providers/show.html.erb
@@ -30,8 +30,7 @@
     <% end %>
 
 <%# Temp hack to allow feature in dev but not int for testing %>
-<% if (ENV.fetch('logo_upload_enabled', 'true') == 'true') &&
-      (LoginGov::Hostdata.env != 'int') %>
+<% if Figaro.env.logo_upload_enabled == 'true' %>
   <h4><label for="logo_file">Uploaded Logo:</label></h4>
   <% if service_provider.logo_file.attached? %>
     <p class="font-mono-xs margin-top-0" name="logo_file">

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  logo_enabled = ENV.fetch('logo_upload_enabled', 'true') == 'true'
+  logo_enabled = Figaro.env.logo_upload_enabled == 'true'
   config.active_storage.service = logo_enabled ? :amazon : :local
   # Allow SVG's only because we will always serve them in an <img> element
   config.active_storage.content_types_to_serve_as_binary -= ['image/svg+xml']

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,8 +29,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  logo_enabled = Figaro.env.logo_upload_enabled == 'true'
-  config.active_storage.service = logo_enabled ? :amazon : :local
+  config.active_storage.service = :local
   # Allow SVG's only because we will always serve them in an <img> element
   config.active_storage.content_types_to_serve_as_binary -= ['image/svg+xml']
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  logo_enabled = ENV.fetch('logo_upload_enabled', 'true') == 'true'
+  logo_enabled = Figaro.env.logo_upload_enabled == 'true'
   config.active_storage.service = logo_enabled ? :amazon : :local
   # Allow SVG's only because we will always serve them in an <img> element
   config.active_storage.content_types_to_serve_as_binary -= ['image/svg+xml']

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,0 +1,1 @@
+ActiveStorage::Service.url_expires_in = 1.week

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,1 +1,2 @@
+# We'd prefer permanent, but 1 week is the max
 ActiveStorage::Service.url_expires_in = 1.week

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -8,7 +8,7 @@ local:
 
 amazon:
   service: S3
-  region: <%= ENV.fetch('aws_region', 'us-west-2') %>
-  bucket: <%= ENV.fetch('aws_logo_bucket', 'login-gov-partner-logos-int.894947205914-us-west-2') %>
+  region: <%= Figaro.env.aws_region %>
+  bucket: <%= Figaro.env.aws_logo_bucket %>
   upload:
     acl: 'public-read'


### PR DESCRIPTION
I had disabled logo upload in `int` - that is reversed.
Went back to `Figaro.env` calls vs. `ENV.fetch...`
Configured `development` to use local storage (logos won't be available to idp)
Configured active storage to make service urls expire in 1 week (was 5 min :-o)