### PR TITLE
update logo updater service object to match what was run on int env

### DIFF
--- a/spec/services/service_provider_logo_updater_spec.rb
+++ b/spec/services/service_provider_logo_updater_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe ServiceProviderLogoUpdater do
     allow(updater).to receive(:logo_path) do |filename|
       Rails.root.join('spec', 'fixtures', filename)
     end
+
+    # don't actually set s3 object's acl
+    allow_any_instance_of(Aws::S3::Client).to receive(:copy_object)
+    allow(updater).to receive(:s3).and_return(Aws::S3::Client.new(stub_responses: true))
   end
 
   describe '#import_logos_to_active_storage' do


### PR DESCRIPTION
This service class was in support of the rake task that imported all of the existing SP logos into ActiveStorage. We'll likely never need it again, but this includes the update I made live on the deployed server to get the content-type to be served out by S3.