### PR TITLE
LG-2971: auto-create account for .gov or .mil users

### DIFF
--- a/app/controllers/users/omniauth_controller.rb
+++ b/app/controllers/users/omniauth_controller.rb
@@ -24,7 +24,9 @@ module Users
     def allow_unregistered_government_user(received_email)
       return if @user
       allowed_tlds = Figaro.env.auto_account_creation_tlds.split(',')
-      return unless allowed_tlds.include?(received_email[-4..-1])
+      return if allowed_tlds.filter do |tld|
+        /(#{Regexp.escape(tld)})\Z/.match?(received_email)
+      end.empty?
 
       @user = User.create(email: received_email)
     end

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -1,5 +1,6 @@
 # These settings are common across environments, but may be overridden
 # in any particular environment
+auto_account_creation_tlds: '.gov,.mil'
 aws_region: us-west-2
 aws_logo_bucket: changeme
 certificate_expiration_warning_period: '60'


### PR DESCRIPTION
As a partner with a `.gov` or `.mil` email address, I don't want to have to email Tom to get access to the login.gov dashboard so I can get started right away. 

Whitelisted TLDs are configurable via `application.yml`. Note, they actually don't have to be TLDs, just the end of the email, e.g., `sa.gov` would whitelist `gsa.gov` and `nasa.gov`.