### PR TITLE
LG-2791: doesn't specify a whitelist of allowed tld's in deployed envs

### DIFF
--- a/app/controllers/users/omniauth_controller.rb
+++ b/app/controllers/users/omniauth_controller.rb
@@ -23,7 +23,7 @@ module Users
 
     def allow_unregistered_government_user(received_email)
       return if @user
-      allowed_tlds = Figaro.env.auto_account_creation_tlds.split(',')
+      allowed_tlds = (Figaro.env.auto_account_creation_tlds || '')&.split(',')
       return if allowed_tlds.filter do |tld|
         /(#{Regexp.escape(tld)})\Z/.match?(received_email)
       end.empty?

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -1,6 +1,5 @@
 # These settings are common across environments, but may be overridden
 # in any particular environment
-auto_account_creation_tlds: '.gov,.mil'
 aws_region: us-west-2
 aws_logo_bucket: changeme
 certificate_expiration_warning_period: '60'
@@ -20,6 +19,7 @@ smtp_password: changeme
 smtp_username: changeme
 
 test: &default
+  auto_account_creation_tlds: '.gov,.mil'
   aws_region: us-west-2
   # aws_logo_bucket: 'changeme'
   certificate_expiration_warning_period: '60'


### PR DESCRIPTION
Removes the tld whitelist from the default so that we can more precisely control each env via app.yml.