### PR TITLE
LG-3048: use case insensitive seach when adding emails to a team

### DIFF
--- a/app/forms/manage_users_form.rb
+++ b/app/forms/manage_users_form.rb
@@ -23,9 +23,7 @@ class ManageUsersForm
   private
 
   def users_from_user_emails
-    existing_users = User.where(email: user_emails).to_a
-    missing_users = (user_emails - existing_users.map(&:email)).map { |e| User.new(email: e) }
-
+    missing_users = missing_emails.map { |e| User.new(email: e) }
     (existing_users + missing_users).sort_by(&:email)
   end
 
@@ -34,5 +32,14 @@ class ManageUsersForm
       next if email.match(Devise.email_regexp)
       errors.add(:base, "#{email} is not a valid email address")
     end
+  end
+
+  def existing_users
+    User.where('lower(email) IN (?)', user_emails.map(&:downcase)).to_a
+  end
+
+  def missing_emails
+    existing_emails = existing_users.map { |user| user.email.downcase }
+    user_emails.filter { |email| !existing_emails.include? email.downcase }
   end
 end

--- a/app/forms/manage_users_form.rb
+++ b/app/forms/manage_users_form.rb
@@ -11,7 +11,8 @@ class ManageUsersForm
   end
 
   def submit(user_emails:)
-    @user_emails = user_emails
+    # Devise makes emails case insensitive by downcasing prior to saving
+    @user_emails = user_emails.map(&:downcase)
 
     return false unless valid?
 
@@ -27,19 +28,19 @@ class ManageUsersForm
     (existing_users + missing_users).sort_by(&:email)
   end
 
+  def missing_emails
+    existing_emails = existing_users.map(&:email)
+    user_emails.filter { |email| !existing_emails.include? email }
+  end
+
+  def existing_users
+    User.where(email: user_emails).to_a
+  end
+
   def user_emails_are_valid_email_addresses
     user_emails.each do |email|
       next if email.match(Devise.email_regexp)
       errors.add(:base, "#{email} is not a valid email address")
     end
-  end
-
-  def existing_users
-    User.where('lower(email) IN (?)', user_emails.map(&:downcase)).to_a
-  end
-
-  def missing_emails
-    existing_emails = existing_users.map { |user| user.email.downcase }
-    user_emails.filter { |email| !existing_emails.include? email.downcase }
   end
 end

--- a/spec/features/manage_users_spec.rb
+++ b/spec/features/manage_users_spec.rb
@@ -47,6 +47,6 @@ feature 'manage users', :js do
 
     click_on 'Save'
 
-    expect(page).to have_content('Nonsense is not a valid email address')
+    expect(page).to have_content('nonsense is not a valid email address')
   end
 end

--- a/spec/forms/manage_users_form_spec.rb
+++ b/spec/forms/manage_users_form_spec.rb
@@ -4,12 +4,12 @@ describe ManageUsersForm do
   let(:team) { create(:team) }
   let(:user_already_on_the_team) { create(:user, teams: [team]) }
   let(:user_not_already_on_the_team) { create(:user) }
-  let(:email_for_nonexistent_user) { 'nonexistent@gsa.gov' }
+  let(:email_for_nonexistent_user) { 'NonExistent@gsa.gov' }
 
   let(:user_emails) do
     [
-      user_already_on_the_team.email,
-      user_not_already_on_the_team.email,
+      user_already_on_the_team.email.upcase,
+      user_not_already_on_the_team.email.upcase,
       email_for_nonexistent_user,
     ]
   end
@@ -20,7 +20,7 @@ describe ManageUsersForm do
     it 'creates users that do not exist and adds users to the team' do
       result = subject.submit(user_emails: user_emails)
 
-      previously_nonexistent_user = User.find_by(email: email_for_nonexistent_user)
+      previously_nonexistent_user = User.find_by(email: email_for_nonexistent_user.downcase)
       team_users = team.reload.users
 
       expect(result).to eq(true)


### PR DESCRIPTION
**Why?** Adding an existing user to the dashboard does not work with uppercase characters.