### PR TITLE
Pull agency_id from team, so it correctly updates in JSON to the IDP

### DIFF
--- a/app/controllers/api/service_providers_controller.rb
+++ b/app/controllers/api/service_providers_controller.rb
@@ -25,7 +25,7 @@ module Api
     end
 
     def approved_service_providers
-      ServiceProvider.all
+      ServiceProvider.includes(:logo_file_attachment, :agency).all
     end
   end
 end

--- a/app/serializers/service_provider_serializer.rb
+++ b/app/serializers/service_provider_serializer.rb
@@ -26,6 +26,10 @@ class ServiceProviderSerializer < ActiveModel::Serializer
     object&.agency&.name
   end
 
+  def agency_id
+    object&.agency&.id
+  end
+
   def cert
     object.saml_client_cert
   end

--- a/spec/controllers/api/service_providers_controller_spec.rb
+++ b/spec/controllers/api/service_providers_controller_spec.rb
@@ -6,8 +6,10 @@ describe Api::ServiceProvidersController do
   end
 
   describe '#index' do
+    let(:team) { build(:team, agency: build(:agency)) }
+
     it 'returns active, approved SPs' do
-      sp = create(:service_provider, active: true, approved: true)
+      sp = create(:service_provider, active: true, approved: true, team: team)
       serialized_sp = ServiceProviderSerializer.new(sp).to_h
 
       get :index
@@ -16,7 +18,7 @@ describe Api::ServiceProvidersController do
     end
 
     xit 'does not return un-approved SPs' do
-      sp = create(:service_provider, active: true, approved: false)
+      sp = create(:service_provider, active: true, approved: false, team: team)
       serialized_sp = ServiceProviderSerializer.new(sp).to_h
 
       get :index
@@ -25,7 +27,7 @@ describe Api::ServiceProvidersController do
     end
 
     it 'includes non-active SPs' do
-      sp = create(:service_provider, active: false, approved: true)
+      sp = create(:service_provider, active: false, approved: true, team: team)
       serialized_sp = ServiceProviderSerializer.new(sp).to_h
 
       get :index

--- a/spec/controllers/api/service_providers_controller_spec.rb
+++ b/spec/controllers/api/service_providers_controller_spec.rb
@@ -6,10 +6,8 @@ describe Api::ServiceProvidersController do
   end
 
   describe '#index' do
-    let(:team) { build(:team, agency: build(:agency)) }
-
     it 'returns active, approved SPs' do
-      sp = create(:service_provider, active: true, approved: true, team: team)
+      sp = create(:service_provider, :with_team, active: true, approved: true)
       serialized_sp = ServiceProviderSerializer.new(sp).to_h
 
       get :index
@@ -18,7 +16,7 @@ describe Api::ServiceProvidersController do
     end
 
     xit 'does not return un-approved SPs' do
-      sp = create(:service_provider, active: true, approved: false, team: team)
+      sp = create(:service_provider, :with_team, active: true, approved: false)
       serialized_sp = ServiceProviderSerializer.new(sp).to_h
 
       get :index
@@ -27,7 +25,7 @@ describe Api::ServiceProvidersController do
     end
 
     it 'includes non-active SPs' do
-      sp = create(:service_provider, active: false, approved: true, team: team)
+      sp = create(:service_provider, :with_team, active: false, approved: true)
       serialized_sp = ServiceProviderSerializer.new(sp).to_h
 
       get :index

--- a/spec/serializers/service_provider_serializer_spec.rb
+++ b/spec/serializers/service_provider_serializer_spec.rb
@@ -4,10 +4,12 @@ RSpec.describe ServiceProviderSerializer do
   subject(:serializer) { ServiceProviderSerializer.new(service_provider) }
   let(:fixture_path) { File.expand_path('../fixtures', __dir__) }
   let(:logo_filename) { 'logo.svg' }
+  let(:team_agency_id) { SecureRandom.random_number(10_000) }
   let(:service_provider) do
     sp = create(:service_provider,
           redirect_uris: ['http://localhost:9292/result', 'x-example-app:/result'],
-          updated_at: Time.zone.now)
+          updated_at: Time.zone.now,
+          team: create(:team, agency: create(:agency, id: team_agency_id)))
     sp.logo_file.attach(io: File.open(fixture_path + "/#{logo_filename}"), filename: logo_filename)
     sp.update(logo: logo_filename)
     sp.reload
@@ -23,6 +25,10 @@ RSpec.describe ServiceProviderSerializer do
         expect(as_json[:logo]).to eq('logo.svg')
         expect(as_json[:remote_logo_key]).to eq(service_provider.logo_file.key)
       end
+    end
+
+    it 'gets the agency_id from the team' do
+      expect(as_json[:agency_id]).to eq(team_agency_id)
     end
   end
 end


### PR DESCRIPTION
**Problem**

in INT dashboard `urn:gov:dhs.cbp.jobs:openidconnect:aws-goes-dev` and`urn:gov:dhs.cbp.pspd:openidconnect:pspd-ttp-dev` have the same agency/team, but in IDP they don't

The issue is that the IDP pulls `agency_id` out of JSON, which was being pulled as a direct attribute, but in dashboard this should come from the team association.

**Solution**

Fix the JSON serializer