### PR TITLE
Add soft deletion to User model

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@ class UsersController < ApplicationController
   before_action -> { authorize User }
 
   def index
-    @users = User.all
+    @users = User.all.sorted
   end
 
   def new

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,12 @@
 class User < ApplicationRecord
+  acts_as_paranoid
+
   devise :trackable, :timeoutable
   has_many :user_teams, dependent: :nullify
   has_many :teams, through: :user_teams
   has_many :service_providers, through: :teams
 
-  validates :email, uniqueness: true
+  validates_with UserValidator, on: :create
 
   scope :sorted, -> { order(email: :asc) }
 

--- a/app/validators/user_validator.rb
+++ b/app/validators/user_validator.rb
@@ -1,0 +1,7 @@
+class UserValidator < ActiveModel::Validator
+  def validate(record)
+    if User.find_by_email(record.email)
+      record.errors.add(:email, I18n.t('notices.user_already_exists'))
+    end
+  end
+end

--- a/app/validators/user_validator.rb
+++ b/app/validators/user_validator.rb
@@ -1,7 +1,6 @@
 class UserValidator < ActiveModel::Validator
   def validate(record)
-    if User.find_by_email(record.email)
-      record.errors.add(:email, I18n.t('notices.user_already_exists'))
-    end
+    return unless User.where(email: record.email).exists?
+    record.errors.add(:email, I18n.t('notices.user_already_exists'))
   end
 end

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -3,7 +3,6 @@
 <%= simple_form_for(@user,
     html: { autocomplete: 'off', role: 'form' },
     url: users_path) do |form| %>
-  <%= form.error_notification %>
   <%= render 'form', form: form %>
   <%= form.button :submit, 'Create', :class => "usa-button" %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,7 +72,7 @@ en:
       sent.
     team_delete_failed: Only teams without apps can be deleted. Reassign or delete
       the apps first.
-    user_already_exists: User already exists
+    user_already_exists: This user already exists
     user_deleted: Success! You have deleted %{email}
   omniauth:
     logout_fail: Logout failed

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,8 +10,9 @@ en:
       delete_service_provider: Delete
       edit_service_provider: Edit
       trigger_idp_refresh: Publish service providers
+    confirm_service_provider: Are you sure you want to delete this service provider?
+      This cannot be undone.
     required_field: Indicates a required field.
-    confirm_service_provider: 'Are you sure you want to delete this service provider? This cannot be undone.'
   headings:
     service_providers:
       edit: Edit service provider
@@ -27,18 +28,21 @@ en:
       new: Create new user team
       new_team: Create a new team
       sub_index: Manage user teams
-      temporary_warning_team_user: "**Warning** Changing your team's agency will affect the UUIDs of the users of an application in this team. Only add an agency if you are prepared to migrate your users across applications."
+      temporary_warning_team_user: "**Warning** Changing your team's agency will affect
+        the UUIDs of the users of an application in this team. Only add an agency
+        if you are prepared to migrate your users across applications."
     users:
       edit: Edit user
       index: Users
       new_user: Create a new user
   home:
-    body_intro: Use the dashboard to manage your login.gov test integrations.
     body_dev_docs_html: Visit our %{href_dev_docs} to learn more.
-    body_partners_html: Interested in login.gov for your federal government applications? Visit %{href_partners}
+    body_intro: Use the dashboard to manage your login.gov test integrations.
+    body_partners_html: Interested in login.gov for your federal government applications?
+      Visit %{href_partners}
+    deployed_by_html: Deployed %{time} ago. View %{href}.
     dev_docs_link: developer documentation
     partners_link: login.gov/partners
-    deployed_by_html: Deployed %{time} ago. View %{href}.
   links:
     aria:
       delete: Delete %{name}
@@ -62,14 +66,21 @@ en:
   notices:
     service_provider_deleted: Success! You have deleted %{issuer}
     service_provider_saved: Success! You have saved %{issuer}
-    service_providers_refresh_failed: Failed to publish service providers. Email partners@login.gov for support.
-    service_providers_refreshed: Success! Service providers publish request has been sent.
+    service_providers_refresh_failed: Failed to publish service providers. Email partners@login.gov
+      for support.
+    service_providers_refreshed: Success! Service providers publish request has been
+      sent.
+    team_delete_failed: Only teams without apps can be deleted. Reassign or delete
+      the apps first.
+    user_already_exists: User already exists
     user_deleted: Success! You have deleted %{email}
-    team_delete_failed: Only teams without apps can be deleted. Reassign or delete the apps first.
   omniauth:
     logout_fail: Logout failed
     logout_ok: Successfully logged out
-  session_timedout: For your safety, we signed you out after being idle for %{session_timeout}. Please sign in again.
-  session_timeout_warning: We noticed you haven't been very active, hence we will sign you out in %{time_left_in_session}. Please click '%{continue_text}' to remain signed in.
+  session_timedout: For your safety, we signed you out after being idle for %{session_timeout}.
+    Please sign in again.
+  session_timeout_warning: We noticed you haven't been very active, hence we will
+    sign you out in %{time_left_in_session}. Please click '%{continue_text}' to remain
+    signed in.
   shared:
     official_site: An official website of the United States government

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -78,9 +78,12 @@ describe User do
       user.email = email
       user.save
       expect(user).to be_valid
-      duplicate = User.new(email: email)
-      duplicate.save
-      expect(duplicate).not_to be_valid
+      user_with_same_email = User.new(email: email)
+      user_with_same_email.save
+      expect(user_with_same_email).not_to be_valid
+      user.destroy
+      user_with_same_email.save
+      expect(user_with_same_email).to be_valid
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -71,4 +71,16 @@ describe User do
       expect(user.scoped_teams).to eq(Team.all)
     end
   end
+
+  describe 'validates' do
+    it 'uniqueness of email address' do
+      email = 'joe@gsa.gov'
+      user.email = email
+      user.save
+      expect(user).to be_valid
+      duplicate = User.new(email: email)
+      duplicate.save
+      expect(duplicate).not_to be_valid
+    end
+  end
 end


### PR DESCRIPTION
Surprisingly, the original User model validation:
```
validates :email, uniqueness: true
```
Does not leverage `act_as_paranoid` to add the `deleted_at` query scope:
![Screen Shot 2020-06-11 at 9 13 28 AM](https://user-images.githubusercontent.com/1053255/84517020-a7e68700-ac9c-11ea-80c3-348781d79315.png)

So I added a custom validator that works:
```
validates_with UserValidator, on: :create
```
![Screen Shot 2020-06-11 at 9 17 59 AM](https://user-images.githubusercontent.com/1053255/84517048-b16fef00-ac9c-11ea-8046-be37db63f82b.png)

There are currently no Spanish/French translations in the app, so I didn't break the trend.  I just updated/normalized `config/locales/en.yml`.