### PR TITLE
Cleanup partner self-service onboarding

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -70,7 +70,7 @@ class TeamsController < AuthenticatedController
       team_params
     else
       user_ids = team_params[:user_ids] || []
-      team_params.merge('user_ids': (user_ids << current_user.id.to_s))
+      team_params.merge(user_ids: (user_ids << current_user.id.to_s))
     end
   end
 end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -11,9 +11,8 @@ class TeamsController < AuthenticatedController
     @team = Team.new(update_params_with_current_user)
 
     if @team.save
-
       flash[:success] = 'Success'
-      redirect_to team_path(@team.id)
+      redirect_to new_team_manage_user_path(@team.id)
     else
       render :new
     end
@@ -70,7 +69,8 @@ class TeamsController < AuthenticatedController
     if current_user.admin?
       team_params
     else
-      team_params.merge('user_ids': (team_params[:user_ids] << current_user.id.to_s))
+      user_ids = team_params[:user_ids] || []
+      team_params.merge('user_ids': (user_ids << current_user.id.to_s))
     end
   end
 end

--- a/spec/features/teams_spec.rb
+++ b/spec/features/teams_spec.rb
@@ -14,11 +14,9 @@ feature 'User teams CRUD' do
     select('GSA', from: 'Agency')
 
     click_on 'Create'
-    expect(current_path).to eq(team_path(Team.last))
+    expect(current_path).to eq(new_team_manage_user_path(Team.last))
     expect(page).to have_content('Success')
     expect(page).to have_content('team name')
-    expect(page).to have_content('GSA')
-    expect(page).to have_content('department name')
   end
 
   context 'User already in a team' do


### PR DESCRIPTION
**Why**: When I put together the manage users story I left some things off

**How**:
- Fix a 500 that prevents people from creating a team after the manage users change
- Redirect to the "Manage Users" page after creating a team