### PR TITLE
Fixed inconsistent headings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ group :development, :test do
 end
 
 group :test do
+  gem 'axe-matchers'
   gem 'capybara-selenium'
   gem 'climate_control'
   gem 'codeclimate-test-reporter', require: nil

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,13 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.1.1)
       aws-eventstream (~> 1.0, >= 1.0.2)
+    axe-matchers (2.6.0)
+      dumb_delegator (~> 0.8)
+      virtus (~> 1.0)
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     bcrypt (3.1.13)
     better_errors (2.5.1)
       coderay (>= 1.0.0)
@@ -166,6 +173,8 @@ GEM
     codeclimate-test-reporter (1.0.8)
       simplecov (<= 0.13)
     coderay (1.1.2)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     colorize (0.8.1)
     concurrent-ruby (1.1.6)
     crack (0.4.3)
@@ -173,6 +182,8 @@ GEM
     crass (1.0.6)
     database_cleaner (1.7.0)
     debug_inspector (0.0.3)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     devise (4.7.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -187,11 +198,13 @@ GEM
     dotenv-rails (2.7.5)
       dotenv (= 2.7.5)
       railties (>= 3.2, < 6.1)
+    dumb_delegator (0.8.1)
     easy_translate (0.5.1)
       thread
       thread_safe
     enum_help (0.0.17)
       activesupport (>= 3.0.0)
+    equalizer (0.0.11)
     erubi (1.9.0)
     execjs (2.7.0)
     factory_bot (4.11.1)
@@ -227,6 +240,7 @@ GEM
       parser (>= 2.2.3.0)
       rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
+    ice_nine (0.11.2)
     jmespath (1.4.0)
     jquery-rails (4.3.5)
       rails-dom-testing (>= 1, < 3)
@@ -465,6 +479,11 @@ GEM
     useragent (0.16.10)
     uuid (2.3.8)
       macaddr (~> 1.0)
+    virtus (1.0.5)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
+      equalizer (~> 0.0, >= 0.0.9)
     warden (1.2.8)
       rack (>= 2.0.6)
     web-console (3.7.0)
@@ -499,6 +518,7 @@ DEPENDENCIES
   acts_as_paranoid
   autoprefixer-rails (~> 9.6)
   aws-sdk-s3
+  axe-matchers
   better_errors
   binding_of_caller
   bullet

--- a/app/assets/stylesheets/application.css.scss.erb
+++ b/app/assets/stylesheets/application.css.scss.erb
@@ -28,8 +28,18 @@ $image-path: 'img';
   padding: 9px 20px;
 }
 
+.lg-card {
+  h2 {
+    margin-top: 0;
+  }
+}
+
 .usa-label {
   color: map-get($site-palette, 'site-dark-grey');
+}
+
+.usa-alertx {
+  margin-bottom: 1em;
 }
 
 .usa-navbar .usa-logo {

--- a/app/helpers/service_provider_helper.rb
+++ b/app/helpers/service_provider_helper.rb
@@ -78,6 +78,11 @@ module ServiceProviderHelper
     yamlable_json.to_yaml.delete('\"')
   end
 
+  def sp_active_img_alt(service_provider_is_active)
+    return 'Active service provider' if service_provider_is_active
+    'Inactive service provider'
+  end
+
   private
 
   def config_hash(service_provider)

--- a/app/views/emails/index.html.erb
+++ b/app/views/emails/index.html.erb
@@ -1,4 +1,4 @@
-<div class="usa-display">Emails</div>
+<h1 class="usa-display">Emails</h1>
 
 <table class="usa-table">
   <thead>

--- a/app/views/env/index.html.erb
+++ b/app/views/env/index.html.erb
@@ -1,4 +1,4 @@
-<div class="usa-display">Environments status</div>
+<h1 class="usa-display">Environments status</h1>
 <% @deploy_statuses.each do |environment| %>
 
   <h2>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,8 +1,8 @@
-<div class="usa-prose">
 <% unless user_signed_in? %>
-  <p class="usa-intro">
+  <h1 class="usa-display">
     <%= t 'home.body_intro' %>
-  </p>
+  </h1>
+  <div class="usa-prose">
   <p>
     <%= t 'home.body_dev_docs_html',
         href_dev_docs: link_to(t('home.dev_docs_link'), 'https://developers.login.gov') %>
@@ -11,5 +11,5 @@
     <%= t 'home.body_partners_html',
         href_partners: link_to(t('home.partners_link'), 'https://login.gov/partners') %>
   </p>
-<% end %>
 </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,9 +36,9 @@
   <body>
     <a class="usa-skipnav" href="#main-content">Skip to main content</a>
 
-    <div class="usa-banner">
+    <header class="usa-banner">
       <div class="usa-accordion">
-        <header class="usa-banner__header">
+        <div class="usa-banner__header">
           <div class="usa-banner__inner">
             <div class="grid-col-auto">
               <%= image_tag 'img/us_flag_small.png', class: 'usa-banner__header-flag', alt: 'U.S. flag' %>
@@ -52,7 +52,7 @@
               <span class="usa-banner__button-text">Here’s how you know</span>
             </button>
           </div>
-        </header>
+        </div>
         <div class="usa-banner__content usa-accordion__content" id="gov-banner" hidden>
           <div class="grid-row grid-gap-lg">
             <div class="usa-banner__guidance tablet:grid-col-6">
@@ -78,9 +78,9 @@
           </div>
         </div>
       </div>
-    </div>
+    </header>
 
-    <header class="usa-header usa-header--basic" role="banner">
+    <nav class="usa-header usa-header--basic">
       <div class="usa-nav-container">
         <div class="usa-navbar">
           <div class="usa-logo" id="basic-logo">
@@ -90,7 +90,7 @@
           </div>
           <button class="usa-menu-btn">Menu</button>
         </div>
-        <nav role="navigation" class="usa-nav">
+        <div class="usa-nav">
           <button class="usa-nav__close">
             <%= image_tag 'img/close.svg', alt: 'Close' %>
           </button>
@@ -139,9 +139,9 @@
               </li>
             <% end %>
           </ul>
-        </nav>
+        </div>
       </div>
-    </header>
+    </nav>
 
     <div class="usa-overlay"></div>
 

--- a/app/views/service_providers/all.html.erb
+++ b/app/views/service_providers/all.html.erb
@@ -1,8 +1,7 @@
 
-<div class="usa-display">Apps</div>
+<h1 class="usa-display">Apps</h1>
 
 <%= button_to t('forms.buttons.trigger_idp_refresh'), api_service_providers_path, method: :post, :class => "usa-button" %>
-
 
 <table class="usa-table">
   <thead>

--- a/app/views/service_providers/edit.html.erb
+++ b/app/views/service_providers/edit.html.erb
@@ -1,5 +1,5 @@
 
-<div class="usa-display">Editing "<%= service_provider.friendly_name %>"</div>
+<h1 class="usa-display">Editing "<%= service_provider.friendly_name %>"</h1>
 
 <%= simple_form_for(service_provider, html: { autocomplete: 'off', role: 'form', class: 'service-provider-form usa-form usa-form--large' }) do |form| %>
   <% selected_team = @service_provider.group_id %>

--- a/app/views/service_providers/index.html.erb
+++ b/app/views/service_providers/index.html.erb
@@ -1,4 +1,4 @@
-<div class="usa-display">My apps</div>
+<h1 class="usa-display">My apps</h1>
 
 <%= button_to t('headings.service_providers.new_app'), new_service_provider_path, method: :get, :class => "usa-button" %>
 

--- a/app/views/service_providers/new.html.erb
+++ b/app/views/service_providers/new.html.erb
@@ -1,7 +1,5 @@
 
-<div class="usa-display">New test app</div>
-
-
+<h1 class="usa-display">New test app</h1>
 
 <%= simple_form_for(@service_provider, html: { autocomplete: 'off', role: 'form', class: 'service-provider-form usa-form usa-form--large' }) do |form| %>
   <%= render 'form', form: form %>

--- a/app/views/service_providers/show.html.erb
+++ b/app/views/service_providers/show.html.erb
@@ -1,37 +1,37 @@
 <%= link_to 'Back to apps', '/service_providers', :class => 'usa-link' %>
 
 
-<div class="usa-display">Details for "<%= service_provider.friendly_name %>"</div>
+<h1 class="usa-display">Details for "<%= service_provider.friendly_name %>"</h1>
 
-<h4><label for="name">Friendly name:</label></h4>
+<h2><label for="name">Friendly name:</label></h2>
 <p class="font-mono-xs margin-top-0" name="name"><%= service_provider.friendly_name %></p>
 
-<h4><label for="description">Description:</label></h4>
+<h2><label for="description">Description:</label></h2>
 <p class="font-mono-xs margin-top-0" name="description"><%= service_provider.description %></p>
 
-<h4><label for="agency">Agency:</label></h4>
+<h2><label for="agency">Agency:</label></h2>
 <p class="font-mono-xs margin-top-0" name="agency"><%= service_provider&.agency&.name %></p>
 
-<h4><label for="team">Team:</label></h4>
+<h2><label for="team">Team:</label></h2>
 <p class="font-mono-xs margin-top-0" name="agency"><%= service_provider.team %></p>
 
-<h4><label for="identity_protocol">Identity protocol:</label></h4>
+<h2><label for="identity_protocol">Identity protocol:</label></h2>
 <p class="font-mono-xs margin-top-0" name="identity_protocol"><%= service_provider.identity_protocol %></p>
 
-<h4><label for="ial_friendly">Identity verification level (IAL):</label></h4>
+<h2><label for="ial_friendly">Identity verification level (IAL):</label></h2>
 <p class="font-mono-xs margin-top-0" name="ial_friendly"><%= service_provider.ial_friendly %></p>
 
-<h4><label for="issuer">Issuer:</label></h4>
+<h2><label for="issuer">Issuer:</label></h2>
 <p class="font-mono-xs margin-top-0" name="issuer"><%=  service_provider.issuer %></p>
 
     <% if current_user.admin? %>
-      <h4><label for="production_issuer">Production Issuer:</label></h4>
+      <h2><label for="production_issuer">Production Issuer:</label></h2>
       <p class="font-mono-xs margin-top-0" name="production_issuer"><%=  service_provider.production_issuer %></p>
     <% end %>
 
 <%# Temp hack to allow feature in dev but not int for testing %>
 <% if Figaro.env.logo_upload_enabled == 'true' %>
-  <h4><label for="logo_file">Uploaded Logo:</label></h4>
+  <h2><label for="logo_file">Uploaded Logo:</label></h2>
   <% if service_provider.logo_file.attached? %>
     <p class="font-mono-xs margin-top-0" name="logo_file">
       <%= image_tag url_for(service_provider.logo_file), height: "120px" %>
@@ -42,61 +42,66 @@
     </p>
   <% end %>
 <% else %>
-  <h4><label for="logo">Logo:</label></h4>
+  <h2><label for="logo">Logo:</label></h2>
+  <% if service_provider.logo %>
   <p class="font-mono-xs margin-top-0" name="logo">
     <a href="https://github.com/18F/identity-idp/tree/master/app/assets/images/sp-logos/<%= service_provider.logo %>" class="usa-link">
       <%= service_provider.logo %>
     </a>
   </p>
+  <% end %>
 <% end %>
 
     <% if service_provider.identity_protocol == 'saml' %>
-    <h4><label for="acs_url">Assertion Consumer Service URL:</label></h4>
+    <h2><label for="acs_url">Assertion Consumer Service URL:</label></h2>
 <p class="font-mono-xs margin-top-0" name="acs_url"><%= service_provider.acs_url %></p>
 
-<h4><label for="assertion_consumer_logout_service_url">Assertion Consumer Logout Service URL:</label></h4>
+<h2><label for="assertion_consumer_logout_service_url">Assertion Consumer Logout Service URL:</label></h2>
 <p class="font-mono-xs margin-top-0" name="assertion_consumer_logout_service_url"><%= service_provider.assertion_consumer_logout_service_url %></p>
 
-<h4><label for="assertion_consumer_logout_service_url">SP Initiated Login URL:</label></h4>
+<h2><label for="assertion_consumer_logout_service_url">SP Initiated Login URL:</label></h2>
 <p class="font-mono-xs margin-top-0" name="assertion_consumer_logout_service_url"><%= service_provider.sp_initiated_login_url %></p>
 
-<h4><label for="block_encryption">SAML Assertion Encryption:</label></h4>
+<h2><label for="block_encryption">SAML Assertion Encryption:</label></h2>
 <p class="font-mono-xs margin-top-0" name="block_encryption"><%= service_provider.block_encryption %></p>
     <% end %>
 
 
-<h4><label for="saml_client_cert">Public certificate:</label></h4>
+<h2><label for="saml_client_cert">Public certificate:</label></h2>
 <pre><code><%= service_provider.saml_client_cert %></code></pre>
         <% unless service_provider.saml_client_cert.blank? %>
         <p class="font-mono-xs margin-top-0" name="saml_client_cert">Expires:
         <%= render partial: 'certificate_expiration', locals: { app: service_provider } %></p>
         <% end %>
 
-<h4><label for="return_to_sp_url">Return to App URL:</label></h4>
+<h2><label for="return_to_sp_url">Return to App URL:</label></h2>
 <p class="font-mono-xs margin-top-0" name="return_to_sp_url"><%= service_provider.return_to_sp_url %></p>
 
-<h4><label for="failure_to_proof_url">Failure to Proof URL:</label></h4>
+<h2><label for="failure_to_proof_url">Failure to Proof URL:</label></h2>
 <p class="font-mono-xs margin-top-0" name="failure_to_proof_url"><%= service_provider.failure_to_proof_url %></p>
 
-<h4><label for="push_notification_url">Push Notification URL:</label></h4>
+<h2><label for="push_notification_url">Push Notification URL:</label></h2>
 <p class="font-mono-xs margin-top-0" name="push_notification_url"><%= service_provider.push_notification_url %></p>
 
     <% if service_provider.identity_protocol == 'openid_connect' %>
-        <h4><label for="uris">Redirect URIs</label></h4>
+        <h2><label for="uris">Redirect URIs</label></h2>
     <% end %>
     <% if service_provider.identity_protocol == 'saml' %>
-        <h4><label for="uris">Additional Redirect URIs</label></h4>
+        <h2><label for="uris">Additional Redirect URIs</label></h2>
     <% end %>
     <p class="font-mono-xs margin-top-0" name="uris"><%= (service_provider.redirect_uris || []).sort.join('<br>').html_safe %></p>
 
-<h4><label for="attribute_bundle">Attribute bundle:</label></h4>
+<h2><label for="attribute_bundle">Attribute bundle:</label></h2>
 <p class="font-mono-xs margin-top-0" name="attribute_bundle"><%= (service_provider.attribute_bundle || []).sort.join(', ') %></p>
 
-<h4><label for="active">Active</label></h4>
-<p class="font-mono-xs margin-top-0" name="active"><%= image_tag service_provider.active? ? 'img/alerts/success.svg' : 'img/alerts/error.svg', height: '27', width: '27', :class =>'margin-bottom-neg-105' %></p>
+<h2><label for="active">Active</label></h2>
+<p class="font-mono-xs margin-top-0" name="active"><%= image_tag service_provider.active? ? 'img/alerts/success.svg' : 'img/alerts/error.svg',
+                                                                 height: '27', width: '27',
+                                                                 :class => 'margin-bottom-neg-105',
+                                                                 :alt => sp_active_img_alt(service_provider.active?) %></p>
 
 <% if current_user.admin? %>
-<h4><label for="service_provider_yaml">Service Provider config as YAML</label></h4>
+<h2><label for="service_provider_yaml">Service Provider config as YAML</label></h2>
 <p class="font-mono-xs margin-top-0" name="service_provider_yaml"><%= render 'service_provider_yaml' %></p>
     <%end %>
 

--- a/app/views/teams/_no_teams.html.erb
+++ b/app/views/teams/_no_teams.html.erb
@@ -2,7 +2,7 @@
 <div class='lg-card'>
   <div class='grid-row flex-row flex-align-end'>
     <div class='mobile-lg:grid-col-10'>
-      <h1 class='margin-bottom-05'>Create your first team</h1>
+      <h2 class='margin-bottom-05'>Create your first team</h2>
       <p class='margin-top-05'>Get started with the sandbox environment. Make a team for your integration project.</p>
     </div>
     <div class='mobile-lg:grid-col-2 text-right'>

--- a/app/views/teams/_teams_list.html.erb
+++ b/app/views/teams/_teams_list.html.erb
@@ -2,9 +2,9 @@
   <div class='lg-card margin-bottom-3'>
     <div class='grid-row flex-row flex-align-end'>
       <div class='mobile-lg:grid-col-10'>
-        <h1 class='margin-y-05'>
+        <h2 class='margin-y-05'>
           <%= link_to team.name, team_path(team), class: 'text-primary text-no-underline' %>
-        </h1>
+        </h2>
         <p class='margin-0'>
           <strong>Agency:</strong> <%= team&.agency&.name %>
         </p>

--- a/app/views/teams/all.html.erb
+++ b/app/views/teams/all.html.erb
@@ -1,4 +1,4 @@
-<div class="usa-display">All teams</div>
+<h1 class="usa-display">All teams</h1>
 
 <div>
   <% if @teams.count > 0 %>
@@ -15,7 +15,7 @@
     <div class='lg-card'>
       <div class='grid-row flex-row flex-align-end'>
         <div class='mobile-lg:grid-col-10'>
-          <h1 class='margin-bottom-05'>Create your first team</h1>
+          <h2 class='margin-bottom-05'>Create your first team</h2>
           <p class='margin-top-05'>Get started with the sandbox environment. Make a team for your integration project.</p>
         </div>
           <div class='mobile-lg:grid-col-2 text-right'>

--- a/app/views/teams/edit.html.erb
+++ b/app/views/teams/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="usa-display">Edit team</div>
+<h1 class="usa-display">Edit team</h1>
 
 
 <%= simple_form_for(@team, html: { autocomplete: 'off', role: 'form', class: 'usa-form usa-form--large' }) do |form| %>
@@ -6,7 +6,7 @@
   <%= render 'form', form: form, agency_required: false, extra_message: t('headings.teams.temporary_warning_team_user') %>
 
   <div>
-    <h4><label for="users">Users: (<%= @team.users.count %>)</label></h4>
+    <h2><label for="users">Users: (<%= @team.users.count %>)</label></h2>
     <ul class="font-mono-xs margin-top-0 usa-list usa-list--unstyled" name="users">
       <% @team.users.each do |u| %>
         <li><%= u.email %></li>

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -1,4 +1,4 @@
-<div class="usa-display">My teams</div>
+<h1 class="usa-display">My teams</h1>
 
 <div>
   <% if @teams.count > 0 %>

--- a/app/views/teams/new.html.erb
+++ b/app/views/teams/new.html.erb
@@ -1,4 +1,4 @@
-<div class="usa-display">New team</div>
+<h1 class="usa-display">New team</h1>
 
 <%= simple_form_for(@team,
     html: { autocomplete: 'off', role: 'form', class: 'usa-form usa-form--large' },

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -3,15 +3,15 @@
   <li><%= link_to "Back to Teams", teams_path, :class => 'usa-link'  %> </li>
 </ul>
 
-<div class="usa-display">Team details for "<%= @team.name %>" </div>
+<h1 class="usa-display">Team details for "<%= @team.name %>" </h1>
 
-<h4><label for="agency">Agency:</label></h4>
+<h2><label for="agency">Agency:</label></h2>
 <p class="font-mono-xs margin-top-0" name="agency"><%= @team&.agency&.name %></p>
 
-<h4><label for="description">Description:</label></h4>
+<h2><label for="description">Description:</label></h2>
 <p class="font-mono-xs margin-top-0" name="description"><%= @team.description %></p>
 
-<h4><label for="users">Users: (<%= @team.users.count %>)</label></h4>
+<h2><label for="users">Users: (<%= @team.users.count %>)</label></h2>
 <ul class="font-mono-xs margin-top-0 usa-list usa-list--unstyled" name="users">
   <% @team.users.each do |u| %>
     <li><%= u.email %></li>
@@ -23,7 +23,7 @@
   class: 'margin-y-1 display-block',
 ) %>
 
-<h4><label for="apps">Apps: (<%= @team.service_providers.count %>)</label></h4>
+<h2><label for="apps">Apps: (<%= @team.service_providers.count %>)</label></h2>
 <ul class="font-mono-xs margin-top-0 usa-list usa-list--unstyled" name="apps">
   <% @team.service_providers.each do |a| %>
     <li><%= link_to a.friendly_name, service_provider_path(a) %></li>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,5 +1,5 @@
 
-<div class="usa-display">Edit user "<%= @user.email %>"</div>
+<h1 class="usa-display">Edit user "<%= @user.email %>"</h1>
 
 <%= simple_form_for(@user, html: { autocomplete: 'off', role: 'form' }) do |form| %>
   <%= form.error_notification %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,5 +1,5 @@
 
-<div class="usa-display">Users</div>
+<h1 class="usa-display">Users</h1>
 
 <div class="actions">
   <%= button_to t('headings.users.new_user'), new_user_path,

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,4 +1,4 @@
-<div class="usa-display">New user</div>
+<h1 class="usa-display">New user</h1>
 
 <%= simple_form_for(@user,
     html: { autocomplete: 'off', role: 'form' },

--- a/app/views/users/none.html.erb
+++ b/app/views/users/none.html.erb
@@ -1,4 +1,4 @@
-<div class="usa-display">No account exists</div>
+<h1 class="usa-display">No account exists</h1>
 
 <p>We were unable to find an account matching your email address in the <%= Rails.application.config.app_name %>.</p>
 

--- a/spec/features/accessibility/emails_spec.rb
+++ b/spec/features/accessibility/emails_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+feature 'Email pages', :js do
+  let(:admin) { create(:admin) }
+
+  before do
+    login_as(admin)
+  end
+
+  scenario 'index page is accessible' do
+    visit emails_path
+    expect(page).to be_accessible
+  end
+end

--- a/spec/features/accessibility/env_spec.rb
+++ b/spec/features/accessibility/env_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+feature 'Environments page', :js do
+  include DeployStatusCheckerHelper
+
+  before do
+    stub_deploy_status
+  end
+
+  scenario 'is accessible' do
+    user = create(:user)
+
+    login_as(user)
+    visit env_path
+    expect(page).to be_accessible
+  end
+end

--- a/spec/features/accessibility/home_spec.rb
+++ b/spec/features/accessibility/home_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+feature 'Home page', :js do
+  scenario 'is accessible' do
+    user = create(:user)
+
+    login_as(user)
+    visit root_path
+
+    expect(page).to be_accessible
+  end
+end

--- a/spec/features/accessibility/service_providers_spec.rb
+++ b/spec/features/accessibility/service_providers_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+feature 'Service provider pages', :js do
+  before do
+    allow(Figaro.env).to receive(:logo_upload_enabled).and_return('false')
+    ENV['logo_upload_enabled'] = 'false'
+  end
+
+  context 'for admins' do
+    scenario 'all service providers page is accessible' do
+      admin = create(:admin)
+      login_as(admin)
+
+      visit service_providers_all_path
+      expect(page).to be_accessible
+    end
+  end
+
+  context 'for users' do
+    let(:user) { create(:user, :with_teams) }
+
+    before do
+      login_as(user)
+    end
+
+    scenario 'index page is accessible' do
+      visit service_providers_path
+      expect(page).to be_accessible
+    end
+
+    scenario 'new service provider page is accessible' do
+      visit new_service_provider_path
+      expect(page).to be_accessible
+    end
+
+    scenario 'service provider details page is accessible' do
+      app = create(:service_provider, :with_users_team, user: user, logo: 'generic.svg')
+      login_as(user)
+
+      visit service_provider_path(app)
+      expect(page).to be_accessible
+    end
+
+    scenario 'service provider details edit page is accessible' do
+      app = create(:service_provider, :with_users_team, user: user)
+      login_as(user)
+
+      visit edit_service_provider_path(app)
+      expect(page).to be_accessible
+    end
+  end
+end

--- a/spec/features/accessibility/teams_spec.rb
+++ b/spec/features/accessibility/teams_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+feature 'Team pages', :js do
+  let(:admin) { create(:admin) }
+
+  before do
+    login_as(admin)
+  end
+
+  scenario 'index page is accessible' do
+    visit teams_path
+    expect(page).to be_accessible
+  end
+
+  scenario 'All teams page is accessible' do
+    visit teams_all_path
+    expect(page).to be_accessible
+  end
+
+  scenario 'New team page is accessible' do
+    visit new_team_path
+    expect(page).to be_accessible
+  end
+
+  scenario 'Edit team page is accessible' do
+    user = create(:user)
+    team = create(:team, users: [user])
+    visit edit_team_path(team)
+    expect(page).to be_accessible
+  end
+
+  scenario 'New team user page is accessible' do
+    create(:agency, name: 'GSA')
+
+    visit new_team_path
+
+    fill_in 'Description', with: 'department name'
+    fill_in 'Name', with: 'team name'
+    select('GSA', from: 'Agency')
+
+    click_on 'Create'
+    expect(page).to be_accessible
+  end
+end

--- a/spec/features/accessibility/users_spec.rb
+++ b/spec/features/accessibility/users_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+feature 'User pages', :js do
+  before do
+    admin = create(:admin)
+    login_as(admin)
+  end
+
+  scenario 'all users page is accessible' do
+    visit users_path
+    expect(page).to be_accessible
+  end
+
+  scenario 'new user page is accessible' do
+    visit new_user_path
+    expect(page).to be_accessible
+  end
+
+  scenario 'edit user page is accessible' do
+    user = create(:user)
+    visit edit_user_path(user)
+    expect(page).to be_accessible
+  end
+end

--- a/spec/helpers/service_provider_helper_spec.rb
+++ b/spec/helpers/service_provider_helper_spec.rb
@@ -91,4 +91,14 @@ describe ServiceProviderHelper do
       end
     end
   end
+
+  describe '#sp_active_img_alt' do
+    it 'returns alt tag indicatng active service provider' do
+      expect(sp_active_img_alt(true)).to eq('Active service provider')
+    end
+
+    it 'returns alt tag indicatng inactive service provider' do
+      expect(sp_active_img_alt(false)).to eq('Inactive service provider')
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,8 @@ ENV['RAILS_ENV'] ||= 'test'
 
 require 'webmock/rspec'
 
+require 'axe/rspec'
+
 # http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   config.color = true

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -14,7 +14,7 @@ Capybara.register_driver :headless_chrome do |app|
 end
 
 Capybara.javascript_driver = :headless_chrome
-Capybara.asset_host = 'http://localhost:3000'
+Capybara.asset_host = 'http://localhost:3001'
 Capybara.default_max_wait_time = 5
 
 Capybara.server = :puma, { Silent: true }


### PR DESCRIPTION
https://cm-jira.usa.gov/browse/LG-3138

Added `axe-matchers` gem and `features/accessibility` specs.  The gem found other issues besides missing headings, including:

- Portions of markup that were not in a specific page region, like `header` or `nav`
- Out-of-sequence headings (like `h1` followed by `h4` instead of `h2`

