### PR TITLE
[LG-2898] Allow admins to enable prompt=login for SPs

### DIFF
--- a/app/controllers/service_providers_controller.rb
+++ b/app/controllers/service_providers_controller.rb
@@ -2,6 +2,7 @@
 class ServiceProvidersController < AuthenticatedController
   before_action :authorize_service_provider
   before_action :authorize_approval, only: [:update]
+  before_action :authorize_allow_prompt_login, only: %i[create update]
 
   def index; end
 
@@ -55,6 +56,13 @@ class ServiceProvidersController < AuthenticatedController
     raise Pundit::NotAuthorizedError, I18n.t('errors.not_authorized')
   end
 
+  def authorize_allow_prompt_login
+    return unless params.require(:service_provider).key?(:allow_prompt_login) &&
+                  !current_user.admin?
+
+    raise Pundit::NotAuthorizedError, I18n.t('errors.not_authorized')
+  end
+
   def validate_and_save_service_provider(initial_action)
     return save_service_provider if service_provider.valid?
     flash[:error] = I18n.t('notices.service_providers_refresh_failed')
@@ -104,6 +112,7 @@ class ServiceProvidersController < AuthenticatedController
       :acs_url,
       :active,
       :agency_id,
+      :allow_prompt_login,
       :approved,
       :assertion_consumer_logout_service_url,
       :block_encryption,

--- a/app/helpers/service_provider_helper.rb
+++ b/app/helpers/service_provider_helper.rb
@@ -83,6 +83,11 @@ module ServiceProviderHelper
     'Inactive service provider'
   end
 
+  def sp_allow_prompt_login_img_alt(sp_allows_prompt_login)
+    return 'prompt=login enabled' if sp_allows_prompt_login
+    'prompt=login disabled'
+  end
+
   private
 
   def config_hash(service_provider)

--- a/app/views/service_providers/_allow_prompt_login.html.erb
+++ b/app/views/service_providers/_allow_prompt_login.html.erb
@@ -1,0 +1,5 @@
+<h2><label for="allow_prompt_login"><code>prompt=login</code> Enabled:</label></h2>
+<p class="font-mono-xs margin-top-0" name="allow_prompt_login"><%= image_tag service_provider.allow_prompt_login? ? 'img/alerts/success.svg' : 'img/alerts/error.svg',
+                                                                height: '27', width: '27',
+                                                                :class => 'margin-bottom-neg-105',
+                                                                :alt => sp_allow_prompt_login_img_alt(service_provider.allow_prompt_login?) %></p>

--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -73,6 +73,20 @@
     <%= form.input :production_issuer,
                    label: 'Production Issuer',
                    input_html: { class: 'usa-input' } %>
+
+    <%# allow_prompt_login checkbox %>
+    <fieldset class="usa-fieldset">
+      <legend class="usa-sr-only">Enable prompt=login</legend>
+      <%= form.label :allow_prompt_login,
+                      label: 'Enable <code>prompt=login</code>'.html_safe,
+                      class: 'usa-label' %>
+      <ul class="usa-input-list">
+        <li>
+          <%= form.check_box :allow_prompt_login, class: 'usa-checkbox__input' %>
+          <%= form.label :allow_prompt_login, 'Enabled', class: 'usa-checkbox__label' %>
+        </li>
+      </ul>
+    </fieldset>
   <% end %>
 
   <%# Temp hack to allow feature in dev but not int for testing %>

--- a/app/views/service_providers/show.html.erb
+++ b/app/views/service_providers/show.html.erb
@@ -24,10 +24,13 @@
 <h2><label for="issuer">Issuer:</label></h2>
 <p class="font-mono-xs margin-top-0" name="issuer"><%=  service_provider.issuer %></p>
 
-    <% if current_user.admin? %>
-      <h2><label for="production_issuer">Production Issuer:</label></h2>
-      <p class="font-mono-xs margin-top-0" name="production_issuer"><%=  service_provider.production_issuer %></p>
-    <% end %>
+<% if current_user.admin? %>
+  <h2><label for="production_issuer">Production Issuer:</label></h2>
+  <p class="font-mono-xs margin-top-0" name="production_issuer"><%=  service_provider.production_issuer %></p>
+  <%= render partial: 'allow_prompt_login', locals: { service_provider: service_provider } %>
+<% elsif service_provider.allow_prompt_login? %>
+  <%= render partial: 'allow_prompt_login', locals: { service_provider: service_provider } %>
+<% end %>
 
 <%# Temp hack to allow feature in dev but not int for testing %>
 <% if Figaro.env.logo_upload_enabled == 'true' %>

--- a/db/migrate/20201130171218_add_allow_prompt_login_to_service_providers.rb
+++ b/db/migrate/20201130171218_add_allow_prompt_login_to_service_providers.rb
@@ -1,0 +1,5 @@
+class AddAllowPromptLoginToServiceProviders < ActiveRecord::Migration[5.2]
+  def change
+    add_column :service_providers, :allow_prompt_login, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_11_125630) do
+ActiveRecord::Schema.define(version: 2020_11_30_171218) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -105,6 +105,7 @@ ActiveRecord::Schema.define(version: 2020_06_11_125630) do
     t.string "push_notification_url"
     t.jsonb "help_text", default: {"sign_in"=>{}, "sign_up"=>{}, "forgot_password"=>{}}
     t.string "remote_logo_key"
+    t.boolean "allow_prompt_login", default: false
     t.index ["group_id"], name: "index_service_providers_on_group_id"
     t.index ["issuer"], name: "index_service_providers_on_issuer", unique: true
   end

--- a/spec/features/service_providers_spec.rb
+++ b/spec/features/service_providers_spec.rb
@@ -101,6 +101,16 @@ feature 'Service Providers CRUD' do
       expect(service_provider.redirect_uris).to eq(['https://bar.com'])
     end
 
+    scenario 'cannot edit allow_prompt_login' do
+      user = create(:user, :with_teams)
+      service_provider = create(:service_provider, :saml, :with_users_team, user: user)
+      login_as(user)
+
+      visit edit_service_provider_path(service_provider)
+
+      expect(page).not_to have_css('input#service_provider_allow_prompt_login')
+    end
+
     # Poltergeist is attempting to click at coordinates [-16333, 22.5] when
     # choosing the protocol in the following four scenarios.
     # rubocop:disable Metrics/LineLength
@@ -196,6 +206,18 @@ feature 'Service Providers CRUD' do
 
       click_on t('forms.buttons.trigger_idp_refresh')
       expect(page).to have_content(I18n.t('notices.service_providers_refreshed'))
+    end
+
+    scenario 'can enable prompt=login for a service provider' do
+      admin = create(:admin)
+      sp = create(:service_provider, :with_team)
+      login_as(admin)
+
+      visit edit_service_provider_path(sp)
+      check 'service_provider_allow_prompt_login'
+      click_on 'Update'
+
+      expect(page).to have_content('Success')
     end
   end
 

--- a/spec/helpers/service_provider_helper_spec.rb
+++ b/spec/helpers/service_provider_helper_spec.rb
@@ -93,12 +93,22 @@ describe ServiceProviderHelper do
   end
 
   describe '#sp_active_img_alt' do
-    it 'returns alt tag indicatng active service provider' do
+    it 'returns alt tag indicating active service provider' do
       expect(sp_active_img_alt(true)).to eq('Active service provider')
     end
 
-    it 'returns alt tag indicatng inactive service provider' do
+    it 'returns alt tag indicating inactive service provider' do
       expect(sp_active_img_alt(false)).to eq('Inactive service provider')
+    end
+  end
+
+  describe '#sp_allow_prompt_login_img_alt' do
+    it 'returns alt tag indicating prompt=login enabled' do
+      expect(sp_allow_prompt_login_img_alt(true)).to eq('prompt=login enabled')
+    end
+
+    it 'returns alt tag indicating prompt=login disabled' do
+      expect(sp_allow_prompt_login_img_alt(false)).to eq('prompt=login disabled')
     end
   end
 end


### PR DESCRIPTION
Add boolean allow_prompt_login attribute to the service_providers table
that defaults to false, matching what the IdP has. Conditionally add
checkbox field for admins on the service provider form to allow editing
of that attribute, and also authorize editing of that attribute at the
controller level. Finally, add display for this attribute in the show
view.

Includes a feature spec for the happy path and unit tests for a new
helper method for the show view.