### PR TITLE
Remove content-type push for uploaded logos

### DIFF
--- a/app/controllers/service_providers_controller.rb
+++ b/app/controllers/service_providers_controller.rb
@@ -148,32 +148,12 @@ class ServiceProvidersController < AuthenticatedController
 
     service_provider.logo_file.attach(logo_file_param)
     cache_logo_info
-    push_logo_content_type
   end
 
   def cache_logo_info
     service_provider.logo = service_provider.logo_file.filename.to_s
     service_provider.remote_logo_key = service_provider.logo_file.key
   end
-
-  # rubocop:disable Metrics/MethodLength
-  def push_logo_content_type
-    return unless using_s3?
-
-    # Set the content-type on the S3 blob or SVG's won't work
-    bucket = Figaro.env.aws_logo_bucket
-    key = service_provider.logo_file.key
-    content_type = service_provider.logo_file.content_type
-    s3.copy_object(
-      bucket:             bucket,
-      content_type:       content_type,
-      copy_source:        "#{bucket}/#{key}",
-      key:                key,
-      metadata_directive: 'REPLACE',
-      acl:                'public-read'
-    )
-  end
-  # rubocop:enable Metrics/MethodLength
 
   def using_s3?
     Rails.application.config.active_storage.service == :amazon

--- a/spec/controllers/service_provider_controller_spec.rb
+++ b/spec/controllers/service_provider_controller_spec.rb
@@ -36,18 +36,6 @@ describe ServiceProvidersController do
         expect(sp.remote_logo_key).to be_present
       end
 
-      context 'when using amazon for storage' do
-        before do
-          allow(subject).to receive(:using_s3?).and_return(true)
-          allow(subject).to receive(:s3).and_return(Aws::S3::Client.new(stub_responses: true))
-        end
-
-        it 'calls copy_object on the S3 client to set content-type' do
-          expect(subject.send(:s3)).to receive(:copy_object)
-          put :update, params: { id: sp.id, service_provider: { issuer: sp.issuer } }
-        end
-      end
-
       context 'with paper trail versioning enabled', versioning: true do
         before do
           put :update, params: { id: sp.id, service_provider: { issuer: sp.issuer } }

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -3,12 +3,13 @@ require 'rails_helper'
 describe Users::SessionsController do
   include Devise::Test::ControllerHelpers
 
+  let(:user) { create(:user) }
+
   describe '#destroy' do
     before do
       request.env["devise.mapping"] = Devise.mappings[:user]
     end
 
-    let(:user) { create(:user) }
     let(:uuid) { '123-asdf-qwerty' }
     let(:omniauth_hash) do
       {
@@ -42,6 +43,21 @@ describe Users::SessionsController do
       it 'redirects to the empty user path' do
         get :destroy
         expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe '#active' do
+    context 'when logged in' do
+      before do
+        allow(controller).to receive(:current_user).and_return(user)
+        request.env["devise.mapping"] = Devise.mappings[:user]
+      end
+
+      it 'returns 200 status' do
+        get :active
+
+        expect(response.status).to eq 200
       end
     end
   end


### PR DESCRIPTION
Implemented by @mitchellhenke, I independently verified that uploading SVG logos worked in his personal sandbox environment.