### PR TITLE
[LG-3733] Add client-size validation of logo size

### DIFF
--- a/app/javascript/packs/validate-logo-size.js
+++ b/app/javascript/packs/validate-logo-size.js
@@ -1,0 +1,23 @@
+document.getElementById("service_provider_logo_file").addEventListener("change", (e) => {
+  // Clear the error div
+  var errorDiv = document.getElementById("logo-upload-error");
+  errorDiv.textContent = "";
+
+  // See https://stackoverflow.com/a/3717847
+  if (!window.FileReader) {
+    console.log("The file API isn't supported on this browser yet.");
+    return;
+  }
+
+  if (!e.target.files) {
+    console.error("This browser doesn't seem to support the `files` property of file inputs.");
+  } else if (!e.target.files[0]) {
+    console.log("No file attached.");
+  } else {
+    var file = e.target.files[0];
+
+    if (file.size > (1024 * 1024)) { // file.size returns bytes
+      errorDiv.textContent = "ERROR: Logo must not be larger than 1MB.";
+    }
+  }
+});

--- a/app/views/service_providers/_logo_upload.html.erb
+++ b/app/views/service_providers/_logo_upload.html.erb
@@ -20,10 +20,12 @@
                     class: 'input-preview' %>
   </div>
   <%= form.hint 'Choose a file to upload as your logo. See <a href="https://developers.login.gov/design-guidelines/#agency-logo-guidelines">guidelines</a> for details.'.html_safe %>
-  <% if service_provider.errors[:logo_file].present? %>
-    <div class='usa-error-message'>
+  <div class='usa-error-message' id='logo-upload-error'>
+    <% if service_provider.errors[:logo_file].present? %>
       ERROR:
       <%= service_provider.errors[:logo_file].join('|') %>
-    </div>
-  <% end %>
+    <% end %>
+  </div>
 </div>
+
+<%= javascript_pack_tag 'validate-logo-size' %>


### PR DESCRIPTION
Warn partners if they select a file greater than 1MB in size. We could
also add all sorts of other client-side validations but keeping it
simple for now.