### PR TITLE
Adds default_aal to service_provider (LG-3825)

### DIFF
--- a/app/controllers/service_providers_controller.rb
+++ b/app/controllers/service_providers_controller.rb
@@ -120,6 +120,7 @@ class ServiceProvidersController < AuthenticatedController
       :friendly_name,
       :group_id,
       :ial,
+      :default_aal,
       :identity_protocol,
       :issuer,
       :logo,

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -41,10 +41,8 @@ class ServiceProvider < ApplicationRecord
     case default_aal
     when 1, nil
       ''
-    when 2
-      'AAL2'
-    when 3
-      'AAL3'
+    when 2, 3
+      "AAL#{default_aal}"
     else
       default_aal.inspect
     end

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -37,6 +37,19 @@ class ServiceProvider < ApplicationRecord
     end
   end
 
+  def aal_friendly
+    case default_aal
+    when 1, nil
+      ''
+    when 2
+      'AAL2'
+    when 3
+      'AAL3'
+    else
+      default_aal.inspect
+    end
+  end
+
   # rubocop:disable MethodLength
   def self.possible_attributes
     possible = %w[

--- a/app/serializers/service_provider_serializer.rb
+++ b/app/serializers/service_provider_serializer.rb
@@ -9,6 +9,7 @@ class ServiceProviderSerializer < ActiveModel::Serializer
     :cert,
     :friendly_name,
     :ial,
+    :default_aal,
     :issuer,
     :logo,
     :remote_logo_key,

--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -49,9 +49,21 @@
                  collection: [['IAL1 (standard)', 1], ['IAL2 (verified identity with SSN)', 2]],
                  selected: form.object.ial,
                  input_html: { class: 'usa-input usa-select'},
-                 label: 'Identity verification level (IAL)',
+                 label: 'Identity Assurance Level (IAL)',
                  #label_html: { class: 'usa-input-required'},
                  hint: 'Choose IAL 1 for standard MFA-protected email-based login. <br/> Choose IAL 2 for identity proofed accounts that require SSN and identity verification (aka LOA3).'.html_safe %>
+
+  <%= form.input :default_aal,
+                 as: :select,
+                 collection: [
+                   ['', 1],
+                   ['AAL2', 2],
+                   ['AAL3', 3]],
+                 selected: form.object.default_aal,
+                 input_html: { class: 'usa-input usa-select'},
+                 label: 'Authentication Assurance Level (AAL)',
+                 #label_html: { class: 'usa-input-required'},
+                 hint: 'Empty - MFA required + remember device is 30 days<br/>AAL2 - MFA required + remember device is 12 hours<br/>AAL3 - unphishable MFA required + remember device is 12 hours'.html_safe %>
 
   <%# The 'ml2' class doesn't appear to exist in the css anymore, so the sample issuers are not indented %>
   <%= form.input :issuer,

--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -61,7 +61,7 @@
                    ['AAL3', 3]],
                  selected: form.object.default_aal,
                  input_html: { class: 'usa-input usa-select'},
-                 label: 'Authentication Assurance Level (AAL)',
+                 label: 'Default Authentication Assurance Level (AAL)',
                  #label_html: { class: 'usa-input-required'},
                  hint: 'Empty - MFA required + remember device is 30 days<br/>AAL2 - MFA required + remember device is 12 hours<br/>AAL3 - unphishable MFA required + remember device is 12 hours'.html_safe %>
 

--- a/app/views/service_providers/show.html.erb
+++ b/app/views/service_providers/show.html.erb
@@ -18,8 +18,11 @@
 <h2><label for="identity_protocol">Identity protocol:</label></h2>
 <p class="font-mono-xs margin-top-0" name="identity_protocol"><%= service_provider.identity_protocol %></p>
 
-<h2><label for="ial_friendly">Identity verification level (IAL):</label></h2>
+<h2><label for="ial_friendly">Identity Assurance Level (IAL):</label></h2>
 <p class="font-mono-xs margin-top-0" name="ial_friendly"><%= service_provider.ial_friendly %></p>
+
+<h2><label for="aal_friendly">Authentication Assurance Level (AAL):</label></h2>
+<p class="font-mono-xs margin-top-0" name="ial_friendly"><%= service_provider.aal_friendly %></p>
 
 <h2><label for="issuer">Issuer:</label></h2>
 <p class="font-mono-xs margin-top-0" name="issuer"><%=  service_provider.issuer %></p>

--- a/app/views/service_providers/show.html.erb
+++ b/app/views/service_providers/show.html.erb
@@ -21,7 +21,7 @@
 <h2><label for="ial_friendly">Identity Assurance Level (IAL):</label></h2>
 <p class="font-mono-xs margin-top-0" name="ial_friendly"><%= service_provider.ial_friendly %></p>
 
-<h2><label for="aal_friendly">Authentication Assurance Level (AAL):</label></h2>
+<h2><label for="aal_friendly">Default Authentication Assurance Level (AAL):</label></h2>
 <p class="font-mono-xs margin-top-0" name="ial_friendly"><%= service_provider.aal_friendly %></p>
 
 <h2><label for="issuer">Issuer:</label></h2>

--- a/db/migrate/20210122185518_add_default_aal_to_service_providers.rb
+++ b/db/migrate/20210122185518_add_default_aal_to_service_providers.rb
@@ -1,0 +1,5 @@
+class AddDefaultAalToServiceProviders < ActiveRecord::Migration[6.0]
+  def change
+    add_column :service_providers, :default_aal, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_30_171218) do
+ActiveRecord::Schema.define(version: 2021_01_22_185518) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -106,6 +106,7 @@ ActiveRecord::Schema.define(version: 2020_11_30_171218) do
     t.jsonb "help_text", default: {"sign_in"=>{}, "sign_up"=>{}, "forgot_password"=>{}}
     t.string "remote_logo_key"
     t.boolean "allow_prompt_login", default: false
+    t.integer "default_aal"
     t.index ["group_id"], name: "index_service_providers_on_group_id"
     t.index ["issuer"], name: "index_service_providers_on_issuer", unique: true
   end

--- a/spec/features/service_providers_spec.rb
+++ b/spec/features/service_providers_spec.rb
@@ -19,6 +19,8 @@ feature 'Service Providers CRUD' do
       fill_in 'Issuer', with: 'urn:gov:gsa:openidconnect.profiles:sp:sso:GSA:app-prod'
       fill_in 'service_provider_logo', with: 'test.png'
       select user.teams[0].name, from: 'service_provider_group_id'
+      select 'IAL2', from: 'Identity Assurance Level (IAL)'
+      select 'AAL2', from: 'Authentication Assurance Level (AAL)'
 
       check 'email'
       check 'first_name'
@@ -30,6 +32,8 @@ feature 'Service Providers CRUD' do
       expect(page).to have_content('urn:gov:gsa:openidconnect.profiles:sp:sso:GSA:app-prod')
       expect(page).to have_content('email')
       expect(page).to have_content(user.teams[0].agency.name)
+      expect(page).to have_content('IAL2')
+      expect(page).to have_content('AAL2')
     end
 
     scenario 'can update service provider team', :js do
@@ -231,6 +235,7 @@ feature 'Service Providers CRUD' do
 
       fill_in 'Friendly name', with: 'change service_provider name'
       fill_in 'Description', with: 'app description foobar'
+      select 'AAL3', from: 'Authentication Assurance Level (AAL)'
       choose 'SAML'
       check 'last_name'
       click_on 'Update'
@@ -240,6 +245,7 @@ feature 'Service Providers CRUD' do
       expect(page).to have_content('app description foobar')
       expect(page).to have_content('change service_provider name')
       expect(page).to have_content('last_name')
+      expect(page).to have_content('AAL3')
     end
     scenario 'user updates service provider but service provider is invalid' do
       user = create(:user)

--- a/spec/serializers/service_provider_serializer_spec.rb
+++ b/spec/serializers/service_provider_serializer_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe ServiceProviderSerializer do
     sp = create(:service_provider,
           redirect_uris: ['http://localhost:9292/result', 'x-example-app:/result'],
           updated_at: Time.zone.now,
-          team: create(:team, agency: create(:agency, id: team_agency_id)))
+          team: create(:team, agency: create(:agency, id: team_agency_id)),
+          ial: 2,
+          default_aal: 3)
     sp.logo_file.attach(io: File.open(fixture_path + "/#{logo_filename}"), filename: logo_filename)
     sp.update(logo: logo_filename)
     sp.reload
@@ -24,6 +26,8 @@ RSpec.describe ServiceProviderSerializer do
         expect(as_json[:redirect_uris]).to eq(service_provider.redirect_uris)
         expect(as_json[:logo]).to eq('logo.svg')
         expect(as_json[:remote_logo_key]).to eq(service_provider.logo_file.key)
+        expect(as_json[:ial]).to eq(2)
+        expect(as_json[:default_aal]).to eq(3)
       end
     end
 


### PR DESCRIPTION
Allow partners to set the default AAL level via the dashboard. This value is used if no AAL value is specified explicitly in the request.

Adds an select input to the SP form to choose a level, and shows it when viewing the SP.