### PR TITLE
Improve first-run documentation guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ These instructions assume [`identity-idp`](https://github.com/18F/identity-idp) 
 
 In the development environment, an administrator user account is created during the setup process with the email address _admin@gsa.gov_ . If this is the first time you've run the application, you will want to log in with this email address, or create an account if one doesn't already exist. After you've logged in as the administrator, you can add new users and teams.
 
+Alternatively, log in using any account, then promote the user to an admin using the `users:make_admin` Rake task:
+
+`bundle exec rake users:make_admin USER=user@example.com,First,Last`
+
 ## Running tests
 
 Run RSpec tests using:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ These instructions assume [`identity-idp`](https://github.com/18F/identity-idp) 
   $ make run
   ```
 
+In the development environment, an administrator user account is created during the setup process with the email address _admin@gsa.gov_ . If this is the first time you've run the application, you will want to log in with this email address, or create an account if one doesn't already exist. After you've logged in as the administrator, you can add new users and teams.
+
 ## Running tests
 
 Run RSpec tests using:


### PR DESCRIPTION
**Why**: As a developer contributing to identity-dashboard, I want to know what to do when I log in for the first time and encounter a "No account exists" warning page, so that I'm not left confused and forced to resort to scouring through source code to figure out how to use the application.