### PR TITLE
HOTFIX: save blank AAL as nil, not 1

### DIFF
--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -56,7 +56,7 @@
   <%= form.input :default_aal,
                  as: :select,
                  collection: [
-                   ['', 1],
+                   ['', nil],
                    ['AAL2', 2],
                    ['AAL3', 3]],
                  selected: form.object.default_aal,


### PR DESCRIPTION
This results in us sending back `http://idmanagement.gov/ns/assurance/aal/1` instead of `urn:gov:gsa:ac:classes:sp:PasswordProtectedTransport:duo`