### PR TITLE
[LG-4479] Revert "Switch Dashboard to only push the latest cert"

### DIFF
--- a/app/serializers/service_provider_serializer.rb
+++ b/app/serializers/service_provider_serializer.rb
@@ -6,7 +6,7 @@ class ServiceProviderSerializer < ActiveModel::Serializer
     :assertion_consumer_logout_service_url,
     :attribute_bundle,
     :block_encryption,
-    :cert,
+    :certs,
     :friendly_name,
     :ial,
     :default_aal,
@@ -31,10 +31,8 @@ class ServiceProviderSerializer < ActiveModel::Serializer
     object&.agency&.id
   end
 
-  # The one expiring latest - no way to know which was added last. Since this is
-  # temporary I think it's ok.
-  def cert
-    object.certificates.sort(&:not_after).last&.to_pem
+  def certs
+    object.certificates.map(&:to_pem)
   end
 
   def updated_at

--- a/spec/serializers/service_provider_serializer_spec.rb
+++ b/spec/serializers/service_provider_serializer_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ServiceProviderSerializer do
         expect(as_json[:remote_logo_key]).to eq(service_provider.logo_file.key)
         expect(as_json[:ial]).to eq(2)
         expect(as_json[:default_aal]).to eq(3)
-        expect(as_json[:cert]).to eq(service_provider.certificates.first.to_pem)
+        expect(as_json[:certs]).to eq([service_provider.certificates.first.to_pem])
       end
     end
 


### PR DESCRIPTION
Reverts 18F/identity-dashboard#413, do not merge until `certs` is re-enabled in the IdP (https://github.com/18F/identity-idp/pull/4898)