### PR TITLE
Accept RISC Security Event Tokens (LG-4413)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'identity_validations', git: 'https://github.com/18f/identity-validations.gi
 gem 'jquery-rails', '>= 4.4.0'
 gem 'json-jwt', '>= 1.13.0'
 gem 'jwt'
+gem 'kaminari'
 gem 'lograge'
 gem 'newrelic_rpm', '>= 6.14.0'
 gem 'nokogiri', '~> 1.11', '>= 1.11.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -280,6 +280,18 @@ GEM
       bindata
     jsonapi-renderer (0.2.2)
     jwt (2.2.2)
+    kaminari (1.2.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.1)
+      kaminari-activerecord (= 1.2.1)
+      kaminari-core (= 1.2.1)
+    kaminari-actionview (1.2.1)
+      actionview
+      kaminari-core (= 1.2.1)
+    kaminari-activerecord (1.2.1)
+      activerecord
+      kaminari-core (= 1.2.1)
+    kaminari-core (1.2.1)
     listen (3.3.3)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -591,6 +603,7 @@ DEPENDENCIES
   jquery-rails (>= 4.4.0)
   json-jwt (>= 1.13.0)
   jwt
+  kaminari
   listen (~> 3.3)
   lograge
   newrelic_rpm (>= 6.14.0)

--- a/app/assets/stylesheets/application.css.scss.erb
+++ b/app/assets/stylesheets/application.css.scss.erb
@@ -111,6 +111,22 @@ $image-path: 'img';
   background: yellow;
 }
 
+.bold-definition {
+  dt {
+    font-weight: bold;
+  }
+
+  dd {
+    margin: 0
+  }
+}
+
+.spaced-definition {
+  dd {
+    padding-bottom: 0.5rem;
+  }
+}
+
 .compact-definition {
   margin-top: 0;
   margin-bottom: 0;

--- a/app/controllers/api/security_events_controller.rb
+++ b/app/controllers/api/security_events_controller.rb
@@ -1,0 +1,18 @@
+module Api
+  class SecurityEventsController < ApplicationController
+    skip_forgery_protection
+
+    def create
+      form = SecurityEventForm.new(body: request.body.read)
+      success, errors = form.submit
+
+      if success
+        head :created
+      else
+        Rails.logger.warn(errors.to_hash)
+
+        head :bad_request
+      end
+    end
+  end
+end

--- a/app/controllers/security_events_controller.rb
+++ b/app/controllers/security_events_controller.rb
@@ -3,8 +3,8 @@ class SecurityEventsController < ApplicationController
 
   def index
     @security_events = current_user.security_events.
-                                    order('issued_at DESC').
-                                    page(params[:page])
+                       order('issued_at DESC').
+                       page(params[:page])
 
     if @security_events.out_of_range?
       redirect_to security_events_path
@@ -15,8 +15,8 @@ class SecurityEventsController < ApplicationController
 
   def all
     @security_events = SecurityEvent.includes(:user).
-                                     order('issued_at DESC')
-                                     page(params[:page])
+                       order('issued_at DESC')
+                       page(params[:page])
 
     if @security_events.out_of_range?
       redirect_to security_events_all_path

--- a/app/controllers/security_events_controller.rb
+++ b/app/controllers/security_events_controller.rb
@@ -6,11 +6,7 @@ class SecurityEventsController < ApplicationController
                        order('issued_at DESC').
                        page(params[:page])
 
-    if @security_events.out_of_range?
-      redirect_to security_events_path
-    else
-      assign_pagination
-    end
+    assign_pagination
   end
 
   def all
@@ -18,11 +14,7 @@ class SecurityEventsController < ApplicationController
                        order('issued_at DESC').
                        page(params[:page])
 
-    if @security_events.out_of_range?
-      redirect_to security_events_all_path
-    else
-      assign_pagination
-    end
+    assign_pagination
   end
 
   private

--- a/app/controllers/security_events_controller.rb
+++ b/app/controllers/security_events_controller.rb
@@ -15,7 +15,7 @@ class SecurityEventsController < ApplicationController
 
   def all
     @security_events = SecurityEvent.includes(:user).
-                       order('issued_at DESC')
+                       order('issued_at DESC').
                        page(params[:page])
 
     if @security_events.out_of_range?

--- a/app/controllers/security_events_controller.rb
+++ b/app/controllers/security_events_controller.rb
@@ -1,0 +1,34 @@
+class SecurityEventsController < ApplicationController
+  before_action -> { authorize SecurityEvent }, only: %i[index all]
+
+  def index
+    @security_events = current_user.security_events
+      .order('issued_at DESC')
+      .page(params[:page])
+
+    if @security_events.out_of_range?
+      redirect_to security_events_path
+    else
+      assign_pagination
+    end
+  end
+
+  def all
+    @security_events = SecurityEvent.includes(:user)
+      .order('issued_at DESC')
+      .page(params[:page])
+
+    if @security_events.out_of_range?
+      redirect_to security_events_all_path
+    else
+      assign_pagination
+    end
+  end
+
+  private
+
+  def assign_pagination
+    @prev_page = @security_events.prev_page && url_for(page: @security_events.prev_page)
+    @next_page = @security_events.next_page && url_for(page: @security_events.next_page)
+  end
+end

--- a/app/controllers/security_events_controller.rb
+++ b/app/controllers/security_events_controller.rb
@@ -1,5 +1,10 @@
 class SecurityEventsController < ApplicationController
   before_action -> { authorize SecurityEvent }, only: %i[index all]
+  before_action -> { authorize security_event }, only: %i[show]
+
+  rescue_from ActiveRecord::RecordNotFound do
+    render file: 'public/404.html', status: :not_found, layout: false
+  end
 
   def index
     @security_events = current_user.security_events.
@@ -17,7 +22,15 @@ class SecurityEventsController < ApplicationController
     assign_pagination
   end
 
+  def show
+    @security_event = security_event
+  end
+
   private
+
+  def security_event
+    @security_event ||= SecurityEvent.find(params[:id])
+  end
 
   def assign_pagination
     @prev_page = @security_events.prev_page && url_for(page: @security_events.prev_page)

--- a/app/controllers/security_events_controller.rb
+++ b/app/controllers/security_events_controller.rb
@@ -2,9 +2,9 @@ class SecurityEventsController < ApplicationController
   before_action -> { authorize SecurityEvent }, only: %i[index all]
 
   def index
-    @security_events = current_user.security_events
-      .order('issued_at DESC')
-      .page(params[:page])
+    @security_events = current_user.security_events.
+                                    order('issued_at DESC').
+                                    page(params[:page])
 
     if @security_events.out_of_range?
       redirect_to security_events_path
@@ -14,9 +14,9 @@ class SecurityEventsController < ApplicationController
   end
 
   def all
-    @security_events = SecurityEvent.includes(:user)
-      .order('issued_at DESC')
-      .page(params[:page])
+    @security_events = SecurityEvent.includes(:user).
+                                     order('issued_at DESC')
+                                     page(params[:page])
 
     if @security_events.out_of_range?
       redirect_to security_events_all_path

--- a/app/forms/security_event_form.rb
+++ b/app/forms/security_event_form.rb
@@ -1,0 +1,74 @@
+# Parses RISC Security Event Token (SETs)
+class SecurityEventForm
+  attr_reader :body
+
+  include ActiveModel::Model
+
+  validates_presence_of :payload
+  validates_presence_of :event_type
+  validates_presence_of :user
+
+  # @param [String] body
+  def initialize(body:)
+    @body = body
+  end
+
+  # @return [Array(Boolean, ActiveModel::Errors)]
+  def submit
+    if valid?
+      SecurityEvent.create!(
+        user: user,
+        uuid: payload['jti'],
+        event_type: event_type,
+        issued_at: payload['iat'] ? Time.zone.at(payload['iat']) : nil,
+        raw_event: payload.to_json,
+      )
+      [ true, nil ]
+    else
+      [ false, errors ]
+    end
+  end
+
+  def payload
+    @payload ||= begin
+      payload = nil
+
+      IdpPublicKeys.all.each do |public_key|
+        payload, _headers = JWT.decode(
+          body, public_key, true, algorithm: 'RS256', leeway: Float::INFINITY
+        )
+        break if payload
+      rescue JWT::DecodeError
+        next
+      end
+
+      if payload
+        payload
+      else
+        errors.add(:jwt, 'could not verify JWT with any known keys')
+        {}
+      end
+    end
+  end
+
+  def event_type
+    (payload['events'] || {}).keys.first
+  end
+
+  def subject
+    payload.dig('events', event_type, 'subject') || {}
+  end
+
+  def user
+    subject_type = subject['subject_type']
+
+    case subject['subject_type']
+    when 'email'
+      User.find_by(email: subject['email'])
+    when 'iss-sub'
+      User.find_by(uuid: subject['sub'])
+    else
+      errors.add(:subject_type, "unknown subject_type #{subject_type}")
+    end
+  end
+end

--- a/app/forms/security_event_form.rb
+++ b/app/forms/security_event_form.rb
@@ -33,6 +33,7 @@ class SecurityEventForm
     )
   end
 
+  # rubocop:disable Metrics/MethodLength
   def payload
     @payload ||= begin
       payload = nil
@@ -43,6 +44,7 @@ class SecurityEventForm
         )
         break if payload
       rescue JWT::DecodeError
+        next
       end
 
       return payload if payload
@@ -51,6 +53,7 @@ class SecurityEventForm
       {}
     end
   end
+  # rubocop:enable Metrics/MethodLength
 
   def event_type
     (payload['events'] || {}).keys.first

--- a/app/models/security_event.rb
+++ b/app/models/security_event.rb
@@ -1,0 +1,3 @@
+class SecurityEvent < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
   has_many :user_teams, dependent: :nullify
   has_many :teams, through: :user_teams
   has_many :service_providers, through: :teams
+  has_many :security_events
 
   validates_with UserValidator, on: :create
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   has_many :user_teams, dependent: :nullify
   has_many :teams, through: :user_teams
   has_many :service_providers, through: :teams
-  has_many :security_events
+  has_many :security_events, dependent: :destroy
 
   validates_with UserValidator, on: :create
 

--- a/app/policies/security_event_policy.rb
+++ b/app/policies/security_event_policy.rb
@@ -7,7 +7,7 @@ class SecurityEventPolicy < BasePolicy
   end
 
   def index?
-    true
+    current_user.present?
   end
 
   def all?

--- a/app/policies/security_event_policy.rb
+++ b/app/policies/security_event_policy.rb
@@ -1,0 +1,16 @@
+class SecurityEventPolicy < BasePolicy
+  attr_reader :current_user, :model
+
+  def initialize(current_user, model)
+    @current_user = current_user
+    @model = model
+  end
+
+  def index?
+    true
+  end
+
+  def all?
+    current_user&.admin?
+  end
+end

--- a/app/policies/security_event_policy.rb
+++ b/app/policies/security_event_policy.rb
@@ -13,4 +13,8 @@ class SecurityEventPolicy < BasePolicy
   def all?
     current_user&.admin?
   end
+
+  def show?
+    current_user.present? && (current_user.admin? || model.user == current_user)
+  end
 end

--- a/app/services/idp_public_keys.rb
+++ b/app/services/idp_public_keys.rb
@@ -1,0 +1,35 @@
+# Ideally this could share an implementation with OmniAuth::LoginDotGov::IdpConfiguration
+# However at this time, that class only exposes one public key
+class IdpPublicKeys
+  # @return [Array<OpenSSL::PKey::PKey>]
+  def self.all
+    @all ||= self.new.load_all
+  end
+
+  attr_reader :idp_url
+
+  def initialize(idp_url: Rails.configuration.oidc['idp_url'])
+    @idp_url = idp_url
+  end
+
+  # @return [Array<OpenSSL::PKey::PKey>]
+  def load_all
+    jwks_configuration[:keys].map do |key_data|
+      JSON::JWK.new(key_data).to_key
+    end
+  end
+
+  def openid_configuration
+    @openid_configuration ||= JSON.parse(
+      Faraday.get(URI.join(idp_url, '.well-known/openid-configuration')).body,
+      symbolize_names: true,
+    )
+  end
+
+  def jwks_configuration
+    @jwks_configuration ||= JSON.parse(
+      Faraday.get(openid_configuration[:jwks_uri]).body,
+      symbolize_names: true
+    )
+  end
+end

--- a/app/services/idp_public_keys.rb
+++ b/app/services/idp_public_keys.rb
@@ -3,7 +3,7 @@
 class IdpPublicKeys
   # @return [Array<OpenSSL::PKey::PKey>]
   def self.all
-    @all ||= self.new.load_all
+    @all ||= new.load_all
   end
 
   attr_reader :idp_url
@@ -22,7 +22,7 @@ class IdpPublicKeys
   def openid_configuration
     @openid_configuration ||= JSON.parse(
       Faraday.get(URI.join(idp_url, '.well-known/openid-configuration')).body,
-      symbolize_names: true,
+      symbolize_names: true
     )
   end
 

--- a/app/services/user_session.rb
+++ b/app/services/user_session.rb
@@ -4,12 +4,6 @@ class UserSession
   def initialize(info)
     @email = info['email']
     @user = User.find_by(email: email) || unregistered_government_user
-
-    puts "====="
-    puts info.inspect
-    puts "===="
-
-
     @user&.update!(uuid: info['uuid'])
   end
 

--- a/app/services/user_session.rb
+++ b/app/services/user_session.rb
@@ -4,6 +4,12 @@ class UserSession
   def initialize(info)
     @email = info['email']
     @user = User.find_by(email: email) || unregistered_government_user
+
+    puts "====="
+    puts info.inspect
+    puts "===="
+
+
     @user&.update!(uuid: info['uuid'])
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -97,14 +97,13 @@
           <ul class="usa-nav__primary usa-accordion">
             <% if user_signed_in? %>
               <li class="usa-nav__primary-item">
-                <a class="usa-nav__link" href="<%= service_providers_path %>">
-                  <span>Apps</span>
-                </a>
+                <%= link_to 'Apps', service_providers_path, class: 'usa-nav__link' %>
               </li>
               <li class="usa-nav__primary-item">
-                <a class="usa-nav__link" href="<%= teams_path %>">
-                  <span>Teams</span>
-                </a>
+                <%= link_to 'Teams', teams_path, class: 'usa-nav__link' %>
+              </li>
+              <li class="usa-nav__primary-item">
+                <%= link_to 'Security Events', security_events_path, class: 'usa-nav__link' %>
               </li>
               <% if current_user.admin? %>
                 <li class="usa-nav__primary-item">
@@ -113,16 +112,19 @@
                   </button>
                   <ul id="unique-id-1" class="usa-nav__submenu">
                     <li class="usa-nav__submenu-item">
-                      <a href="<%= service_providers_all_path %>">All apps</a>
+                      <%= link_to 'All apps', service_providers_all_path %>
                     </li>
                     <li class="usa-nav__submenu-item">
-                      <a href="<%= users_path %>">Users</a>
+                      <%= link_to 'Users', users_path %>
                     </li>
                     <li class="usa-nav__submenu-item">
-                      <a href=<%= teams_all_path %>>All teams</a>
+                      <%= link_to 'All teams', teams_all_path %>
                     </li>
                     <li class="usa-nav__submenu-item">
-                      <a href="<%= emails_path %>">Emails</a>
+                      <%= link_to 'Emails', emails_path %>
+                    </li>
+                    <li class="usa-nav__submenu-item">
+                      <%= link_to 'All security events', security_events_all_path %>
                     </li>
                   </ul>
                 </li>

--- a/app/views/security_events/_table.html.erb
+++ b/app/views/security_events/_table.html.erb
@@ -14,9 +14,8 @@
             <th scope="col">User</th>
           <% end %>
           <th scope="col">Type</th>
-          <th scope="col">UUID</th>
+          <th scope="col">UUID (click for details)</th>
           <th scope="col">Issued At</th>
-          <th scope="col">Payload</th>
         </tr>
       </thead>
       <tbody>
@@ -31,18 +30,10 @@
               <%= security_event.event_type.split('/').last %>&hellip;
             <% end %>
             <td>
-              <kbd><%= security_event.uuid %></kbd>
+              <%= link_to security_event.uuid, security_event_path(security_event) %>
             </td>
             <td>
               <%= l(security_event.issued_at, format: :long) %>
-            </td>
-            <td>
-              <% if security_event.raw_event %>
-                <details>
-                  <summary class="summary-fix">Show Payload</summary>
-                  <pre><code><%= JSON.pretty_generate(JSON.parse(security_event.raw_event)) %></code></pre>
-                </details>
-              <% end %>
             </td>
           </tr>
         <% end %>

--- a/app/views/security_events/_table.html.erb
+++ b/app/views/security_events/_table.html.erb
@@ -39,7 +39,7 @@
             <td>
               <% if security_event.raw_event %>
                 <details>
-                  <summary>Show Payload</summary>
+                  <summary class="summary-fix">Show Payload</summary>
                   <pre><code><%= JSON.pretty_generate(JSON.parse(security_event.raw_event)) %></code></pre>
                 </details>
               <% end %>

--- a/app/views/security_events/_table.html.erb
+++ b/app/views/security_events/_table.html.erb
@@ -1,0 +1,84 @@
+<%# locals:
+  - security_events
+  - next_page (optional)
+  - prev_page (optional)
+  - show_user (optional)
+%>
+
+<div class="grid-container padding-0">
+  <div class="grid-row">
+    <table class="usa-table grid-col-fill">
+      <thead>
+        <tr>
+          <% if local_assigns[:show_user] %>
+            <th scope="col">User</th>
+          <% end %>
+          <th scope="col">Type</th>
+          <th scope="col">UUID</th>
+          <th scope="col">Issued At</th>
+          <th scope="col">Payload</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% security_events.each do |security_event| %>
+          <tr>
+            <% if local_assigns[:show_user] %>
+              <td>
+                <%= security_event.user.email %>
+              </td>
+            <% end %>
+            <%= content_tag(:td, title: security_event.event_type) do %>
+              <%= security_event.event_type.split('/').last %>&hellip;
+            <% end %>
+            <td>
+              <kbd><%= security_event.uuid %></kbd>
+            </td>
+            <td>
+              <%= l(security_event.issued_at, format: :long) %>
+            </td>
+            <td>
+              <% if security_event.raw_event %>
+                <details>
+                  <summary>Show Payload</summary>
+                  <pre><code><%= JSON.pretty_generate(JSON.parse(security_event.raw_event)) %></code></pre>
+                </details>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<div class="grid-container padding-0">
+  <div class="grid-row">
+    <div class="grid-col-auto">
+      <% if local_assigns[:prev_page] %>
+        <%= link_to prev_page do %>
+          &larr; Previous
+        <% end %>
+      <% else %>
+        <span class="text-base-light">
+          &larr; Previous
+        </span>
+      <% end %>
+    </div>
+
+    <div class="grid-col-fill">
+      &nbsp;
+    </div>
+
+    <div class="grid-col-auto">
+      <% if local_assigns[:next_page] %>
+        <%= link_to next_page do %>
+          Next &rarr;
+        <% end %>
+      <% else %>
+        <span class="text-base-light">
+          Next &rarr;
+        </span>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/security_events/all.html.erb
+++ b/app/views/security_events/all.html.erb
@@ -1,0 +1,9 @@
+<h2>All Security Events</h2>
+
+<%= render partial: 'table',
+           locals: {
+             security_events: @security_events,
+             show_user: true,
+             next_page: @next_page,
+             prev_page: @prev_page,
+          } %>

--- a/app/views/security_events/index.html.erb
+++ b/app/views/security_events/index.html.erb
@@ -1,0 +1,8 @@
+<h2>Your Security Events</h2>
+
+<%= render partial: 'table',
+           locals: {
+             security_events: @security_events,
+             next_page: @next_page,
+             prev_page: @prev_page,
+           } %>

--- a/app/views/security_events/show.html.erb
+++ b/app/views/security_events/show.html.erb
@@ -1,0 +1,25 @@
+<h1>Security Event</h1>
+
+<dl class="bold-definition spaced-definition padding-bottom-2">
+  <dt>User</dt>
+  <dd><%= @security_event.user.email %></dd>
+
+  <dt>Event Type</dt>
+  <dd><%= @security_event.event_type %>
+
+  <dt>UUID (<kbd>jti</kbd>)</dt>
+  <dd><%= @security_event.uuid %></dd>
+
+  <dt>Issued At</dt>
+  <dd>
+    <%= l(@security_event.issued_at, format: :long) %>
+    (<%= time_ago_in_words(@security_event.issued_at) %>)
+  </dd>
+</dl>
+
+
+<h2>Event Payload</h2>
+
+<% if @security_event.raw_event %>
+  <pre><code><%= JSON.pretty_generate(JSON.parse(@security_event.raw_event)) %></code></pre>
+<% end %>

--- a/app/views/service_providers/_certificate.html.erb
+++ b/app/views/service_providers/_certificate.html.erb
@@ -4,7 +4,7 @@ locals:
 - block for extra content inside card (optional)
 %>
 <div class="lg-card margin-top-2">
-  <dl class="compact-definition padding-bottom-2">
+  <dl class="compact-definition bold-definition padding-bottom-2">
     <dt>Issuer</dt>
     <dd><%= certificate.issuer %></dd>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
   get '/service_providers/all' => 'service_providers#all'
   resources :service_providers
 
-  resources :security_events, only: :index
+  resources :security_events, only: [:index, :show]
   get '/security_events/all' => 'security_events#all'
 
   post '/api/security_events' => 'api/security_events#create'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
   get '/service_providers/all' => 'service_providers#all'
   resources :service_providers
 
-  resources :security_events, only: %[index]
+  resources :security_events, only: :index
   get '/security_events/all' => 'security_events#all'
 
   post '/api/security_events' => 'api/security_events#create'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
   get '/service_providers/all' => 'service_providers#all'
   resources :service_providers
 
-  resources :security_events, only: [:index, :show]
+  resources :security_events, only: %i[index show]
   get '/security_events/all' => 'security_events#all'
 
   post '/api/security_events' => 'api/security_events#create'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,9 +20,14 @@ Rails.application.routes.draw do
 
   get '/emails' => 'emails#index'
   get '/service_providers/all' => 'service_providers#all'
+  resources :service_providers
+
+  resources :security_events, only: %[index]
+  get '/security_events/all' => 'security_events#all'
+
+  post '/api/security_events' => 'api/security_events#create'
   get '/api/service_providers' => 'api/service_providers#index'
   post '/api/service_providers' => 'api/service_providers#update'
-  resources :service_providers
 
   root to: 'home#index'
 

--- a/db/migrate/20210412181322_create_security_events.rb
+++ b/db/migrate/20210412181322_create_security_events.rb
@@ -1,0 +1,17 @@
+class CreateSecurityEvents < ActiveRecord::Migration[6.1]
+  def change
+    create_table :security_events do |t|
+      t.integer :user_id, null: false
+      t.string :uuid
+      t.timestamp :issued_at
+      t.string :event_type
+      t.text :raw_event
+
+      t.timestamps
+
+      t.index :user_id
+      t.index :uuid
+      t.index :issued_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_01_225415) do
+ActiveRecord::Schema.define(version: 2021_04_12_181322) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,6 +72,19 @@ ActiveRecord::Schema.define(version: 2021_04_01_225415) do
     t.text "description", default: ""
     t.integer "agency_id"
     t.index ["name"], name: "index_groups_on_name", unique: true
+  end
+
+  create_table "security_events", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "uuid"
+    t.datetime "issued_at"
+    t.string "event_type"
+    t.text "raw_event"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["issued_at"], name: "index_security_events_on_issued_at"
+    t.index ["user_id"], name: "index_security_events_on_user_id"
+    t.index ["uuid"], name: "index_security_events_on_uuid"
   end
 
   create_table "service_providers", id: :serial, force: :cascade do |t|

--- a/spec/controllers/api/security_events_controller_spec.rb
+++ b/spec/controllers/api/security_events_controller_spec.rb
@@ -4,11 +4,12 @@ RSpec.describe Api::SecurityEventsController do
   describe '#create' do
     subject(:action) { post :create, body: body }
 
+    let(:idp_private_key) { OpenSSL::PKey::RSA.new(2048) }
+    let(:idp_public_key) { idp_private_key.public_key }
+    before { allow(IdpPublicKeys).to receive(:all).and_return([idp_public_key]) }
+
     context 'with a valid JWT' do
       let(:user) { create(:user) }
-      let(:idp_private_key) { OpenSSL::PKey::RSA.new(2048) }
-      let(:idp_public_key) { idp_private_key.public_key }
-      before { allow(IdpPublicKeys).to receive(:all).and_return([idp_public_key]) }
 
       let(:payload) do
         {

--- a/spec/controllers/api/security_events_controller_spec.rb
+++ b/spec/controllers/api/security_events_controller_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+RSpec.describe Api::SecurityEventsController do
+  describe '#create' do
+    subject(:action) { post :create, body: body }
+
+    context 'with a valid JWT' do
+      let(:user) { create(:user) }
+      let(:idp_private_key) { OpenSSL::PKey::RSA.new(2048) }
+      let(:idp_public_key) { idp_private_key.public_key }
+      before { allow(IdpPublicKeys).to receive(:all).and_return([idp_public_key]) }
+
+      let(:payload) do
+        {
+          jti: SecureRandom.hex,
+          iat: Time.zone.now.to_i,
+          events: {
+            'https://schemas.openid.net/secevent/risc/event-type/account-purged' => {
+              subject: {
+                subject_type: 'iss-sub',
+                sub: user.uuid,
+                iss: 'https://idp.example.login.gov',
+              }
+            }
+          }
+        }
+      end
+
+      let(:body) do
+        JWT.encode(payload, idp_private_key, 'RS256', typ: 'secevent+jwt')
+      end
+
+      it 'creates a JWT and 201s' do
+        expect { action }.to(change { SecurityEvent.count })
+
+        expect(response).to be_created
+      end
+    end
+
+    context 'with an invalid JWT' do
+      let(:body) { 'aaaa' }
+
+      it 'logs a warning and does not create a SecurityEvent' do
+        expect(Rails.logger).to receive(:warn)
+
+        expect { action }.to_not(change { SecurityEvent.count })
+
+        expect(response).to be_bad_request
+      end
+    end
+  end
+end

--- a/spec/controllers/api/security_events_controller_spec.rb
+++ b/spec/controllers/api/security_events_controller_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe Api::SecurityEventsController do
   describe '#create' do

--- a/spec/controllers/security_events_controller_spec.rb
+++ b/spec/controllers/security_events_controller_spec.rb
@@ -22,10 +22,15 @@ RSpec.describe SecurityEventsController do
       expect(security_events.map(&:user).uniq).to eq([user])
     end
 
-    it 'redirects to the first page from an invalid page' do
-      get :index, params: { page: 1000 }
+    context 'with no events' do
+      before { SecurityEvent.delete_all }
 
-      expect(response).to redirect_to(security_events_path)
+      it 'renders an empty page' do
+        get :index
+
+        expect(assigns[:security_events].size).to eq(0)
+        expect(response).to be_ok
+      end
     end
   end
 
@@ -41,10 +46,15 @@ RSpec.describe SecurityEventsController do
         expect(security_events.map(&:user).uniq).to match_array([user, other_user])
       end
 
-      it 'redirects to the first page from an invalid page' do
-        get :all, params: { page: 1000 }
+      context 'with no events' do
+        before { SecurityEvent.delete_all }
 
-        expect(response).to redirect_to(security_events_all_path)
+        it 'renders an empty page' do
+          get :index
+
+          expect(assigns[:security_events].size).to eq(0)
+          expect(response).to be_ok
+        end
       end
     end
 

--- a/spec/controllers/security_events_controller_spec.rb
+++ b/spec/controllers/security_events_controller_spec.rb
@@ -66,4 +66,48 @@ RSpec.describe SecurityEventsController do
       end
     end
   end
+
+  describe '#show' do
+    subject(:action) { get :show, params: { id: id } }
+    let(:security_event) { create(:security_event, user: user) }
+    let(:id) { security_event.id }
+
+    context 'for an event belonging to the current user' do
+      let(:security_event) { create(:security_event, user: user) }
+
+      it 'renders the event' do
+        action
+        expect(assigns[:security_event]).to eq(security_event)
+      end
+    end
+
+    context 'for an event belonging to a different user' do
+      let(:security_event) { create(:security_event, user: build(:user)) }
+
+      it 'renders an error' do
+        action
+
+        expect(response).to be_unauthorized
+      end
+
+      context 'when the current user is an admin' do
+        let(:user) { create(:admin) }
+
+        it 'renders the event' do
+          action
+          expect(assigns[:security_event]).to eq(security_event)
+        end
+      end
+    end
+
+    context 'for an event that does not exist' do
+      let(:id) { 'abcdef' }
+
+      it '404s' do
+        action
+
+        expect(response).to be_not_found
+      end
+    end
+  end
 end

--- a/spec/controllers/security_events_controller_spec.rb
+++ b/spec/controllers/security_events_controller_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe SecurityEventsController do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+
+  before do
+    sign_in(user)
+
+    2.times do
+      create(:security_event, user: user)
+    end
+    create(:security_event, user: other_user)
+  end
+
+  describe '#index' do
+    it 'renders security events for the current user only' do
+      get :index
+
+      security_events = assigns[:security_events]
+      expect(security_events.size).to eq(2)
+      expect(security_events.map(&:user).uniq).to eq([user])
+    end
+
+    it 'redirects to the first page from an invalid page' do
+      get :index, params: { page: 1000 }
+
+      expect(response).to redirect_to(security_events_path)
+    end
+  end
+
+  describe '#all' do
+    context 'for an admin user' do
+      let(:user) { create(:admin) }
+
+      it 'renders security events for all users' do
+        get :all
+
+        security_events = assigns[:security_events]
+        expect(security_events.size).to eq(3)
+        expect(security_events.map(&:user).uniq).to match_array([user, other_user])
+      end
+
+      it 'redirects to the first page from an invalid page' do
+        get :all, params: { page: 1000 }
+
+        expect(response).to redirect_to(security_events_all_path)
+      end
+    end
+
+    context 'for a non-admin user' do
+      it 'renders an error' do
+        get :all
+
+        expect(response).to be_unauthorized
+      end
+    end
+  end
+end

--- a/spec/factories/security_event.rb
+++ b/spec/factories/security_event.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :security_event do
+    event_type do
+      %w[
+        https://schemas.openid.net/secevent/risc/event-type/account-purged
+        https://schemas.openid.net/secevent/risc/event-type/identifier-recycled
+      ].sample
+    end
+    issued_at { Time.zone.now }
+    uuid { SecureRandom.uuid }
+    raw_event { {}.to_json }
+  end
+end

--- a/spec/forms/security_event_form_spec.rb
+++ b/spec/forms/security_event_form_spec.rb
@@ -1,0 +1,109 @@
+require 'rails_helper'
+
+RSpec.describe SecurityEventForm do
+  subject(:form) { SecurityEventForm.new(body: jwt) }
+
+  let(:idp_private_key) { OpenSSL::PKey::RSA.new(2048) }
+  let(:idp_public_key) { idp_private_key.public_key }
+  before { allow(IdpPublicKeys).to receive(:all).and_return([idp_public_key]) }
+
+  let(:jwt) { JWT.encode(payload, idp_private_key, 'RS256', typ: 'secevent+jwt') }
+  let(:user) { create(:user) }
+
+  let(:payload) do
+    {
+      jti: SecureRandom.hex,
+      iat: Time.zone.now.to_i,
+      events: {
+        'https://schemas.openid.net/secevent/risc/event-type/account-purged' => {
+          subject: {
+            subject_type: 'iss-sub',
+            sub: user.uuid,
+            iss: 'https://idp.example.login.gov',
+          }
+        }
+      }
+    }
+  end
+
+  describe '#submit' do
+    context 'with a valid JWT' do
+      it 'returns [true, nil]' do
+        success, errors = form.submit
+        expect(success).to eq(true)
+        expect(errors).to be_nil
+      end
+
+      it 'records the event in the database' do
+        expect { form.submit }.to(change { SecurityEvent.count }.by(1))
+
+        security_event = SecurityEvent.last
+        aggregate_failures do
+          expect(security_event.user).to eq(user)
+          expect(security_event.event_type).
+            to eq('https://schemas.openid.net/secevent/risc/event-type/account-purged')
+          expect(security_event.uuid).to eq(payload[:jti])
+          expect(security_event.issued_at.to_i).to eq(payload[:iat])
+          expect(JSON.parse(security_event.raw_event)).to eq(JSON.parse(payload.to_json))
+        end
+      end
+    end
+
+    context 'when encoded with an unknown cert' do
+      let(:idp_public_key) do
+        # generate another random cert and use its public key
+        OpenSSL::PKey::RSA.new(2048).public_key
+      end
+
+      it 'returns [false, errors]' do
+        success, errors = form.submit
+        expect(success).to eq(false)
+        expect(errors[:jwt]).to include('could not verify JWT with any known keys')
+      end
+    end
+
+    context 'with an empty payload' do
+      let(:payload) { {} }
+
+      it 'returns [false, errors]' do
+        success, errors = form.submit
+        expect(success).to eq(false)
+        expect(errors[:payload]).to include("can't be blank")
+      end
+    end
+
+    context 'with no event' do
+      before { payload.delete(:events) }
+
+      it 'returns [false, errors]' do
+        success, errors = form.submit
+        expect(success).to eq(false)
+        expect(errors[:event_type]).to include("can't be blank")
+      end
+    end
+
+    context 'with an unknown subject_type' do
+      before do
+        payload[:events].first.last[:subject][:subject_type] = 'foobar'
+      end
+
+      it 'returns [false, errors]' do
+        success, errors = form.submit
+        expect(success).to eq(false)
+        expect(errors[:subject_type]).to include('unknown subject_type foobar')
+      end
+    end
+
+    context 'with a iss-sub for an unknown user' do
+      before do
+        payload[:events].first.last[:subject][:sub] = 'not-a-user-uuid'
+      end
+
+      it 'returns [false, errors]' do
+        success, errors = form.submit
+        expect(success).to eq(false)
+        expect(errors[:user]).to include("can't be blank")
+      end
+    end
+  end
+end

--- a/spec/models/security_event_spec.rb
+++ b/spec/models/security_event_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe SecurityEvent do
+  describe 'Associations' do
+    it { should belong_to(:user) }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,6 +5,7 @@ describe User do
 
   describe 'Associations' do
     it { should have_many(:service_providers) }
+    it { should have_many(:security_events) }
   end
 
   let(:user) { build(:user) }

--- a/spec/policies/security_event_policy_spec.rb
+++ b/spec/policies/security_event_policy_spec.rb
@@ -4,6 +4,14 @@ RSpec.describe SecurityEventPolicy do
   subject(:policy) { SecurityEventPolicy.new(user, SecurityEvent) }
 
   describe '#index?' do
+    context 'when logged out' do
+      let(:user) { nil }
+
+      it 'is false' do
+        expect(policy.index?).to eq(false)
+      end
+    end
+
     context 'for a non-admin user' do
       let(:user) { build(:user) }
 

--- a/spec/policies/security_event_policy_spec.rb
+++ b/spec/policies/security_event_policy_spec.rb
@@ -1,9 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe SecurityEventPolicy do
-  subject(:policy) { SecurityEventPolicy.new(user, SecurityEvent) }
+  subject(:policy) { SecurityEventPolicy.new(user, model) }
 
   describe '#index?' do
+    let(:model) { SecurityEvent }
+
     context 'when logged out' do
       let(:user) { nil }
 
@@ -30,6 +32,8 @@ RSpec.describe SecurityEventPolicy do
   end
 
   describe '#all?' do
+    let(:model) { SecurityEvent }
+
     context 'for a non-admin user' do
       let(:user) { build(:user) }
 
@@ -43,6 +47,47 @@ RSpec.describe SecurityEventPolicy do
 
       it 'is true' do
         expect(policy.all?).to eq(true)
+      end
+    end
+  end
+
+  describe '#show?' do
+    let(:model) { build(:security_event) }
+
+    context 'for a logged out user' do
+      let(:user) { nil }
+
+      it 'is false' do
+        expect(policy.show?).to eq(false)
+      end
+    end
+
+    context 'for a non-admin user' do
+      let(:user) { build(:user) }
+
+      context 'when the event belongs to the user' do
+        let(:model) { build(:security_event, user: user) }
+
+        it 'is true' do
+          expect(policy.show?).to eq(true)
+        end
+      end
+
+      context 'when the event belongs to another user' do
+        let(:another_user) { build(:user) }
+        let(:model) { build(:security_event, user: another_user) }
+
+        it 'is false' do
+          expect(policy.show?).to eq(false)
+        end
+      end
+    end
+
+    context 'for an admin user' do
+      let(:user) { build(:admin) }
+
+      it 'is true' do
+        expect(policy.show?).to eq(true)
       end
     end
   end

--- a/spec/policies/security_event_policy_spec.rb
+++ b/spec/policies/security_event_policy_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe SecurityEventPolicy do
+  subject(:policy) { SecurityEventPolicy.new(user, SecurityEvent) }
+
+  describe '#index?' do
+    context 'for a non-admin user' do
+      let(:user) { build(:user) }
+
+      it 'is true' do
+        expect(policy.index?).to eq(true)
+      end
+    end
+
+    context 'for an admin user' do
+      let(:user) { build(:admin) }
+
+      it 'is true' do
+        expect(policy.index?).to eq(true)
+      end
+    end
+  end
+
+  describe '#all?' do
+    context 'for a non-admin user' do
+      let(:user) { build(:user) }
+
+      it 'is false' do
+        expect(policy.all?).to eq(false)
+      end
+    end
+
+    context 'for an admin user' do
+      let(:user) { build(:admin) }
+
+      it 'is true' do
+        expect(policy.all?).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/services/idp_public_keys_spec.rb
+++ b/spec/services/idp_public_keys_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe IdpPublicKeys do
+  subject(:loader) { IdpPublicKeys.new(idp_url: 'http://idp.example.com') }
+
+  describe '#load_all' do
+    let(:public_keys) do
+      3.times.map do
+        OpenSSL::PKey::RSA.new(2048).public_key
+      end
+    end
+
+    it 'loads from the IDP' do
+      stub_request(:get, 'http://idp.example.com/.well-known/openid-configuration')
+        .to_return(body: {
+          jwks_uri: 'http://idp.example.com/certs',
+        }.to_json)
+
+      stub_request(:get, 'http://idp.example.com/certs')
+        .to_return(body: {
+          keys: public_keys.map { |key| JSON::JWK.new(key) },
+        }.to_json)
+
+      expect(loader.load_all.map(&:to_pem)).to eq(public_keys.map(&:to_pem))
+    end
+  end
+end

--- a/spec/views/security_events/_table.html.erb_spec.rb
+++ b/spec/views/security_events/_table.html.erb_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+RSpec.describe 'security_events/table.html.erb' do
+  subject(:render_partial) do
+    render partial: 'security_events/table',
+          locals: {
+            security_events: security_events,
+            show_user: show_user,
+            prev_page: prev_page,
+            next_page: next_page,
+          }
+  end
+
+  let(:user) { create(:user) }
+  let(:security_events) do
+    2.times.map { create(:security_event, user: user) }
+  end
+  let(:show_user) { false }
+  let(:prev_page) { nil }
+  let(:next_page) { nil }
+
+  it 'renders a table of security events' do
+    render_partial
+
+    rows = Nokogiri::HTML(rendered).css('tbody tr')
+    expect(rows.size).to eq(2)
+
+    expect(rows.map { |r| r.css('td')[1].text.strip }).to eq(security_events.map(&:uuid))
+  end
+
+  context 'with show_user: false' do
+    let(:show_user) { false }
+
+    it 'does not have an email column' do
+      render_partial
+
+      expect(rendered).to_not have_selector('th[scope=col]', text: 'User')
+    end
+  end
+
+  context 'with show_user: true' do
+    let(:show_user) { true }
+
+    it 'adds an email column' do
+      render_partial
+
+      expect(rendered).to have_selector('th[scope=col]', text: 'User')
+      expect(rendered).to include(user.email)
+    end
+  end
+
+  context 'on the first page' do
+    let(:next_page) { '?page=2' }
+
+    it 'has a disabled previous link and an active next link' do
+      render_partial
+
+      expect(rendered).to have_selector('span[class=text-base-light]', text: 'Previous')
+      expect(rendered).to have_selector("a[href='#{next_page}']", text: 'Next')
+    end
+  end
+
+  context 'in a middle page' do
+    let(:prev_page) { '?page=1' }
+    let(:next_page) { '?page=3' }
+
+    it 'has active previous and next links' do
+      render_partial
+
+      expect(rendered).to have_selector("a[href='#{prev_page}']", text: 'Previous')
+      expect(rendered).to have_selector("a[href='#{next_page}']", text: 'Next')
+    end
+  end
+
+  context 'on the last page' do
+    let(:prev_page) { '?page=2' }
+
+    it 'has active a disabled next link and an active previous link' do
+      render_partial
+
+      expect(rendered).to have_selector("a[href='#{prev_page}']", text: 'Previous')
+      expect(rendered).to have_selector('span[class=text-base-light]', text: 'Next')
+    end
+  end
+end


### PR DESCRIPTION
- Record them in the DB
- Show them in the UI

Here's a little tour!

* **Note**: I remembered to add the details/summary CSS fix after I took screenshots, so the triangle *is* there correctly

| notes | screenshot |
| --- | ---- |
| New nav item, view a table of security events for yourself | <img width="1031" alt="Screen Shot 2021-04-12 at 4 42 02 PM" src="https://user-images.githubusercontent.com/458784/114476040-5b1a5800-9bae-11eb-9ea1-ae4a77b1409d.png"> |
| mouse over the event name to see the full name | <img width="576" alt="Screen Shot 2021-04-12 at 4 42 28 PM" src="https://user-images.githubusercontent.com/458784/114476117-84d37f00-9bae-11eb-97a3-03b3c8c97f11.png">  | good ol' details/summary to see the full payload |  <img width="1081" alt="Screen Shot 2021-04-12 at 4 43 33 PM" src="https://user-images.githubusercontent.com/458784/114476175-9e74c680-9bae-11eb-93f8-4c5d602f7ae2.png"> |
| pagination!! because there will be a lot of these |  <img width="1096" alt="Screen Shot 2021-04-12 at 4 41 51 PM" src="https://user-images.githubusercontent.com/458784/114476304-d3811900-9bae-11eb-8d02-b1ab17bcbe63.png"> |
| admins get a new dropdown, they can see events across all users | <img width="1033" alt="Screen Shot 2021-04-12 at 4 43 23 PM" src="https://user-images.githubusercontent.com/458784/114476272-c3693980-9bae-11eb-99ed-7081634cdce9.png"> |



