### PR TITLE
UX feedback: clean up security events pages (LG-4414)

### DIFF
--- a/app/helpers/security_event_helper.rb
+++ b/app/helpers/security_event_helper.rb
@@ -1,0 +1,11 @@
+module SecurityEventHelper
+  def friendly_name(security_event)
+    doc_attrs = DevDocs.find_risc_event(security_event.event_type)
+
+    doc_attrs&.friendly_name || security_event.event_type.split('/').last
+  end
+
+  def event_description(security_event)
+    DevDocs.find_risc_event(security_event.event_type)&.description
+  end
+end

--- a/app/services/dev_docs.rb
+++ b/app/services/dev_docs.rb
@@ -31,7 +31,7 @@ class DevDocs
     Array(json[:supported_events]).map do |attrs|
       RiscEvent.new(**attrs.slice(*RiscEvent.members))
     end.select(&:event_type)
-  rescue Faraday::ConnectionFailed, JSON::ParserError => e
+  rescue Faraday::TimeoutError, Faraday::ConnectionFailed, JSON::ParserError => e
     Rails.logger.warn(e)
     []
   end

--- a/app/services/dev_docs.rb
+++ b/app/services/dev_docs.rb
@@ -1,0 +1,38 @@
+# Helps load metadata from developer documentation site
+class DevDocs
+  RiscEvent = Struct.new(:event_type, :friendly_name, :description, keyword_init: true)
+
+  # @return [Hash<String,RiscEvent>]
+  def self.risc_events
+    Rails.cache.fetch('data/risc.json', expires_in: 12.hours) do
+      new.load_risc_events.map { |risc| [ risc.event_type, risc ] }.to_h
+    end
+  end
+
+  # @return [RiscEvent,nil]
+  def self.find_risc_event(event_type)
+    risc_events[event_type]
+  end
+
+  attr_reader :dev_docs_url
+
+  def initialize(dev_docs_url: Figaro.env.dev_docs_url)
+    @dev_docs_url = dev_docs_url
+  end
+
+  # @return [Array<RiscEvent>]
+  def load_risc_events
+    data_url = URI.join(dev_docs_url, 'data/risc.json')
+    Rails.logger.info("requesting #{data_url}")
+
+    response = Faraday.get(data_url)
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    Array(json[:supported_events]).map do |attrs|
+      RiscEvent.new(**attrs.slice(*RiscEvent.members))
+    end.select(&:event_type)
+  rescue Faraday::ConnectionFailed, JSON::ParserError => e
+    Rails.logger.warn(e)
+    []
+  end
+end

--- a/app/views/security_events/_table.html.erb
+++ b/app/views/security_events/_table.html.erb
@@ -14,7 +14,6 @@
             <th scope="col">User</th>
           <% end %>
           <th scope="col">Type</th>
-          <th scope="col">UUID (click for details)</th>
           <th scope="col">Issued At</th>
         </tr>
       </thead>
@@ -26,11 +25,11 @@
                 <%= security_event.user.email %>
               </td>
             <% end %>
-            <%= content_tag(:td, title: security_event.event_type) do %>
-              <%= security_event.event_type.split('/').last %>&hellip;
-            <% end %>
             <td>
-              <%= link_to security_event.uuid, security_event_path(security_event) %>
+              <%= link_to(
+                    friendly_name(security_event),
+                    security_event_path(security_event)
+                  ) %>
             </td>
             <td>
               <%= l(security_event.issued_at, format: :long) %>

--- a/app/views/security_events/show.html.erb
+++ b/app/views/security_events/show.html.erb
@@ -1,4 +1,8 @@
-<h1>Security Event</h1>
+<h1><%= friendly_name(@security_event) %></h1>
+
+<% if event_description(@security_event) %>
+  <p><%= event_description(@security_event) %></p>
+<% end %>
 
 <dl class="bold-definition spaced-definition padding-bottom-2">
   <dt>User</dt>

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -25,6 +25,7 @@ smtp_domain: changeme
 smtp_password: changeme
 smtp_username: changeme
 post_logout_redirect_uri: http://localhost:3001
+dev_docs_url: 'https://developers.login.gov'
 
 test: &default
   auto_account_creation_tlds: '.gov,.mil'

--- a/spec/helpers/security_event_helper_spec.rb
+++ b/spec/helpers/security_event_helper_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe SecurityEventHelper do
   before do
     allow(DevDocs).to receive(:risc_events).and_return(
       'https://.../identifier-recycled' => DevDocs::RiscEvent.new(
-        friendly_name: 'Identifier Recycled'
+        friendly_name: 'Identifier Recycled',
       ),
       'https://.../recovery-activated' => DevDocs::RiscEvent.new(
         friendly_name: 'Recovery Activated',
         description: 'Some event that does things like XYZ',
-      )
+      ),
     )
   end
 

--- a/spec/helpers/security_event_helper_spec.rb
+++ b/spec/helpers/security_event_helper_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe SecurityEventHelper do
+  before do
+    allow(DevDocs).to receive(:risc_events).and_return(
+      'https://.../identifier-recycled' => DevDocs::RiscEvent.new(
+        friendly_name: 'Identifier Recycled'
+      ),
+      'https://.../recovery-activated' => DevDocs::RiscEvent.new(
+        friendly_name: 'Recovery Activated',
+        description: 'Some event that does things like XYZ',
+      )
+    )
+  end
+
+  describe '#friendly_name' do
+    it 'is the friendly name when DevDocs has one' do
+      security_event = build(:security_event, event_type: 'https://.../identifier-recycled')
+
+      expect(friendly_name(security_event)).to eq('Identifier Recycled')
+    end
+
+    it 'falls back to the last segment of the URL' do
+      security_event = build(:security_event, event_type: 'https://.../some-unknown-event')
+
+      expect(friendly_name(security_event)).to eq('some-unknown-event')
+    end
+  end
+
+  describe '#event_description' do
+    it 'is the description when DevDocs has one' do
+      security_event = build(:security_event, event_type: 'https://.../recovery-activated')
+
+      expect(event_description(security_event)).to eq('Some event that does things like XYZ')
+    end
+
+    it 'falls back to nil' do
+      security_event = build(:security_event, event_type: 'https://.../identifier-recycled')
+
+      expect(event_description(security_event)).to be_nil
+    end
+  end
+end

--- a/spec/services/dev_docs_spec.rb
+++ b/spec/services/dev_docs_spec.rb
@@ -1,0 +1,124 @@
+require 'rails_helper'
+
+RSpec.describe DevDocs do
+  before { Rails.cache.clear }
+
+  let(:risc_data_url) { URI.join(Figaro.env.dev_docs_url, 'data/risc.json') }
+
+  let(:risc_json) do
+    {
+      supported_events: [
+        {
+          friendly_name: 'Identifier Recycled',
+          event_type: 'https://schemas.openid.net/secevent/risc/event-type/identifier-recycled',
+        },
+        {
+          friendly_name: 'Account Purged',
+          event_type: 'https://schemas.openid.net/secevent/risc/event-type/account-purged',
+        },
+        {
+          friendly_name: 'Recovery Activated',
+          event_type: 'https://schemas.openid.net/secevent/risc/event-type/recovery-activated',
+          description: 'Some event that does things like XYZ',
+        },
+      ]
+    }
+  end
+
+  before do
+    stub_request(:get, risc_data_url).
+      to_return(body: risc_json.to_json)
+  end
+
+  describe '.risc_events' do
+    let(:event_type) { 'https://schemas.openid.net/secevent/risc/event-type/identifier-recycled' }
+
+    it 'is a hash of event_type => RiscEvent struct' do
+      expect(DevDocs.risc_events).to be_a(Hash)
+      expect(DevDocs.risc_events[event_type]).to be_a(DevDocs::RiscEvent)
+    end
+
+    it 'caches the network request' do
+      3.times { DevDocs.risc_events }
+
+      expect(a_request(:get, risc_data_url)).to have_been_made.once
+    end
+  end
+
+  describe '.find_risc_event' do
+    let(:event_type) { 'https://schemas.openid.net/secevent/risc/event-type/identifier-recycled' }
+
+    it 'looks up events by event_type' do
+      expect(DevDocs.find_risc_event(event_type)).to eq(DevDocs::RiscEvent.new(
+        friendly_name: 'Identifier Recycled',
+        event_type: 'https://schemas.openid.net/secevent/risc/event-type/identifier-recycled',
+      ))
+    end
+  end
+
+  subject(:dev_docs) { DevDocs.new }
+
+  describe '#load_risc_events' do
+    subject(:load_risc_events) { dev_docs.load_risc_events }
+
+    context 'with a network error' do
+      before do
+        stub_request(:get, risc_data_url).to_timeout
+      end
+
+      it 'logs a warning and returns an empty array' do
+        expect(Rails.logger).to receive(:warn)
+
+        expect(load_risc_events).to eq([])
+      end
+    end
+
+    context 'when the endpoint 404s' do
+      before do
+        stub_request(:get, risc_data_url).
+          to_return(status: 404, body: '<html />')
+      end
+
+      it 'logs a warning and returns an empty array' do
+        expect(Rails.logger).to receive(:warn)
+
+        expect(load_risc_events).to eq([])
+      end
+    end
+
+    context 'when the endpoint has an unexpected data shape' do
+      before do
+        stub_request(:get, risc_data_url).
+          to_return(body: { foo_bar: true }.to_json)
+      end
+
+      it 'returns an empty array' do
+        expect(load_risc_events).to eq([])
+      end
+    end
+
+    context 'when the endpoint has new unknown attributes' do
+      before do
+        stub_request(:get, risc_data_url).
+          to_return(body: risc_json.to_json)
+      end
+
+      let(:risc_json) do
+        {
+          supported_events: [
+            some_new_key: 'aaaa',
+            event_type: '/identifier-recycled',
+            friendly_name: 'Identifier Recycled',
+          ]
+        }
+      end
+
+      it 'ignores them' do
+        expect(load_risc_events.first).to eq(DevDocs::RiscEvent.new(
+          event_type: '/identifier-recycled',
+          friendly_name: 'Identifier Recycled',
+        ))
+      end
+    end
+  end
+end

--- a/spec/services/dev_docs_spec.rb
+++ b/spec/services/dev_docs_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe DevDocs do
           event_type: 'https://schemas.openid.net/secevent/risc/event-type/recovery-activated',
           description: 'Some event that does things like XYZ',
         },
-      ]
+      ],
     }
   end
 
@@ -109,7 +109,7 @@ RSpec.describe DevDocs do
             some_new_key: 'aaaa',
             event_type: '/identifier-recycled',
             friendly_name: 'Identifier Recycled',
-          ]
+          ],
         }
       end
 

--- a/spec/services/idp_public_keys_spec.rb
+++ b/spec/services/idp_public_keys_spec.rb
@@ -1,27 +1,49 @@
 require 'rails_helper'
 
 RSpec.describe IdpPublicKeys do
-  subject(:loader) { IdpPublicKeys.new(idp_url: 'http://idp.example.com') }
+  before { Rails.cache.clear }
 
-  describe '#load_all' do
-    let(:public_keys) do
-      3.times.map do
-        OpenSSL::PKey::RSA.new(2048).public_key
-      end
+  let(:public_keys) do
+    3.times.map do
+      OpenSSL::PKey::RSA.new(2048).public_key
+    end
+  end
+
+  before do
+    stub_request(:get, 'http://idp.example.com/.well-known/openid-configuration').
+      to_return(body: {
+        jwks_uri: 'http://idp.example.com/certs',
+      }.to_json)
+
+    stub_request(:get, 'http://idp.example.com/certs').
+      to_return(body: {
+        keys: public_keys.map { |key| JSON::JWK.new(key) },
+      }.to_json)
+  end
+
+
+  describe '.all' do
+    before do
+      allow(Rails).to receive_message_chain(:configuration, :oidc, :[]).
+        and_return('http://idp.example.com')
     end
 
+    it 'caches the response from the IDP' do
+      3.times { IdpPublicKeys.all }
+
+      expect(a_request(:get, 'http://idp.example.com/.well-known/openid-configuration')).
+        to have_been_requested.once
+      expect(a_request(:get, 'http://idp.example.com/certs')).
+        to have_been_requested.once
+    end
+  end
+
+  subject(:loader) { IdpPublicKeys.new(idp_url: 'http://idp.example.com') }
+
+
+  describe '#load_all' do
     it 'loads from the IDP' do
-      stub_request(:get, 'http://idp.example.com/.well-known/openid-configuration').
-        to_return(body: {
-          jwks_uri: 'http://idp.example.com/certs',
-        }.to_json)
-
-      stub_request(:get, 'http://idp.example.com/certs').
-        to_return(body: {
-          keys: public_keys.map { |key| JSON::JWK.new(key) },
-        }.to_json)
-
-      expect(loader.load_all.map(&:to_pem)).to eq(public_keys.map(&:to_pem))
+      expect(loader.load_all.map { |jwk| jwk.to_key.to_pem }).to eq(public_keys.map(&:to_pem))
     end
   end
 end

--- a/spec/views/security_events/_table.html.erb_spec.rb
+++ b/spec/views/security_events/_table.html.erb_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe 'security_events/table.html.erb' do
           }
   end
 
+  before do
+    allow(DevDocs).to receive(:risc_events).and_return({})
+  end
+
   let(:user) { create(:user) }
   let(:security_events) do
     2.times.map { create(:security_event, user: user) }
@@ -24,8 +28,6 @@ RSpec.describe 'security_events/table.html.erb' do
 
     rows = Nokogiri::HTML(rendered).css('tbody tr')
     expect(rows.size).to eq(2)
-
-    expect(rows.map { |r| r.css('td')[1].text.strip }).to eq(security_events.map(&:uuid))
   end
 
   context 'with show_user: false' do


### PR DESCRIPTION
Feedback from going through this with @juliaelman 

- Drop UUID from table, it's not useful
- Load friendly names for events if we can (from dev docs PR: https://github.com/18F/identity-dev-docs/pull/178)
- Load descriptions for event if we can

Next PR
- Adding search to the table

Screenshots

| before | after |
| --- | --- |
| ![Screen Shot 2021-04-15 at 8 59 05 AM](https://user-images.githubusercontent.com/458784/114900968-33530c00-9dc9-11eb-8722-3086ca557721.png) | <img alt="Screen Shot 2021-04-15 at 8 58 40 AM" src="https://user-images.githubusercontent.com/458784/114900994-3817c000-9dc9-11eb-9266-92a9edbbd996.png"> |
| <img alt="Screen Shot 2021-04-15 at 8 59 13 AM" src="https://user-images.githubusercontent.com/458784/114901039-436aeb80-9dc9-11eb-9500-f5cecc713604.png"> | <img  alt="Screen Shot 2021-04-15 at 8 59 36 AM" src="https://user-images.githubusercontent.com/458784/114901068-49f96300-9dc9-11eb-802d-e814a7bbb9c5.png"> |

