### PR TITLE
RISC UX Improvements: filter/search by user email (LG-4414)

### DIFF
--- a/app/policies/security_event_policy.rb
+++ b/app/policies/security_event_policy.rb
@@ -14,6 +14,8 @@ class SecurityEventPolicy < BasePolicy
     current_user&.admin?
   end
 
+  alias_method :search?, :all?
+
   def show?
     current_user.present? && (current_user.admin? || model.user == current_user)
   end

--- a/app/views/security_events/all.html.erb
+++ b/app/views/security_events/all.html.erb
@@ -1,5 +1,18 @@
 <h2>All Security Events</h2>
 
+<%= form_with url: security_events_search_path, method: :post do |form| %>
+  <fieldset class="usa-fieldset">
+    <legend class="usa-legend">
+      Filter Events By
+    </legend>
+
+    <%= form.label :email, 'Email', class: 'usa-label' %>
+    <%= form.text_field :email, class: 'usa-input', value: @user&.email %>
+
+    <%= form.submit 'Search', class: 'usa-button margin-top-1' %>
+  </fieldset>
+<% end %>
+
 <%= render partial: 'table',
            locals: {
              security_events: @security_events,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
   resources :service_providers
 
   get '/security_events/all' => 'security_events#all'
+  post '/security_events/search' => 'security_events#search'
   resources :security_events, only: %i[index show]
 
   post '/api/security_events' => 'api/security_events#create'

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,6 +4,8 @@ FactoryBot.define do
     sequence(:first_name) { |n| "FirstName#{n}" }
     sequence(:last_name) { |n| "LastName#{n}" }
 
+    uuid { SecureRandom.uuid }
+
     trait :with_teams do
       teams { create_list(:team, 3) }
     end

--- a/spec/policies/security_event_policy_spec.rb
+++ b/spec/policies/security_event_policy_spec.rb
@@ -91,4 +91,24 @@ RSpec.describe SecurityEventPolicy do
       end
     end
   end
+
+  describe '#search?' do
+    let(:model) { SecurityEvent }
+
+    context 'for a non-admin user' do
+      let(:user) { build(:user) }
+
+      it 'is false' do
+        expect(policy.search?).to eq(false)
+      end
+    end
+
+    context 'for an admin user' do
+      let(:user) { build(:admin) }
+
+      it 'is true' do
+        expect(policy.search?).to eq(true)
+      end
+    end
+  end
 end

--- a/spec/routing/security_events_spec.rb
+++ b/spec/routing/security_events_spec.rb
@@ -7,4 +7,11 @@ RSpec.describe '/security_events' do
       action: 'all',
     )
   end
+
+  it 'routes search to #search' do
+    expect(post: '/security_events/search').to route_to(
+      controller: 'security_events',
+      action: 'search',
+    )
+  end
 end


### PR DESCRIPTION
Adds new search field

| notes | screenshot |
| --- |--- |
| search field, empty | <img width="1013" alt="Screen Shot 2021-04-15 at 9 59 31 AM" src="https://user-images.githubusercontent.com/458784/114910782-276c4780-9dd3-11eb-8ee1-d366d5bf149b.png"> |
| filters results by email | <img width="1000" alt="Screen Shot 2021-04-15 at 9 59 48 AM" src="https://user-images.githubusercontent.com/458784/114910847-381cbd80-9dd3-11eb-9888-4cda98ebe4af.png"> |
| flashes a warning for unknown emails |  <img width="1019" alt="Screen Shot 2021-04-15 at 10 00 05 AM" src="https://user-images.githubusercontent.com/458784/114910894-45d24300-9dd3-11eb-8d99-095ce2ca1651.png"> |


