### PR TITLE
Use an in-memory cache store in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,8 +57,7 @@ Rails.application.configure do
 
   config.log_level = :info
 
-  # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :memory_store, { size: 64.megabytes }
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque


### PR DESCRIPTION
**Why**: the default is a file store, and we don't have
permission to write to the tmp directory it uses

I tested this out on a `dev` box to make sure the config was acceptable

[NewRelic error link](https://one.newrelic.com/launcher/nr1-core.explorer?pane=eyJiYXJjaGFydCI6ImJhcmNoYXJ0IiwidG9wRmFjZXQiOiJ0cmFuc2FjdGlvblVpTmFtZSIsInBhZ2UiOiJzaG93IiwicHJpbWFyeUZhY2V0IjoiZXJyb3IuY2xhc3MiLCJ0cmFjZUlkIjoiOTFhZWY4NTUtOWVkZC0xMWViLWExOGItMDI0MmFjMTEwMDA4XzE3NDQxXzI0ODg3IiwiZmlsdGVycyI6W3sia2V5IjoiZXJyb3IuZXhwZWN0ZWQiLCJ2YWx1ZSI6Im5vdCB0cnVlIn0seyJrZXkiOiJlcnJvci5jbGFzcyIsInZhbHVlIjoiRXJybm86OkVBQ0NFUyIsImxpa2UiOmZhbHNlfV0sIm5lcmRsZXRJZCI6ImVycm9ycy11aS5vdmVydmlldyIsImVudGl0eUlkIjoiTVRNM05qTTNNSHhCVUUxOFFWQlFURWxEUVZSSlQwNThNVEE0T0RnMU9UUXgifQ==&sidebars[0]=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5hY3Rpb25zIiwiZW50aXR5SWQiOiJNVE0zTmpNM01IeEJVRTE4UVZCUVRFbERRVlJKVDA1OE1UQTRPRGcxT1RReCIsInNlbGVjdGVkTmVyZGxldCI6eyJuZXJkbGV0SWQiOiJlcnJvcnMtdWkub3ZlcnZpZXcifX0=&platform[accountId]=1376370&platform[timeRange][duration]=1800000)