### PR TITLE
[LG-4072] Remove middle_name from attribute bundle input

### DIFF
--- a/app/helpers/service_provider_helper.rb
+++ b/app/helpers/service_provider_helper.rb
@@ -88,6 +88,14 @@ module ServiceProviderHelper
     'prompt=login disabled'
   end
 
+  def sp_attribute_bundle(service_provider)
+    return '' unless service_provider.attribute_bundle.present?
+
+    service_provider.attribute_bundle.select do |attribute|
+      ServiceProvider.possible_attributes.include? attribute
+    end.sort.join(', ')
+  end
+
   private
 
   def config_hash(service_provider)

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -53,7 +53,6 @@ class ServiceProvider < ApplicationRecord
     possible = %w[
       email
       first_name
-      middle_name
       last_name
       address1
       address2

--- a/app/views/service_providers/show.html.erb
+++ b/app/views/service_providers/show.html.erb
@@ -98,7 +98,7 @@
     <p class="font-mono-xs margin-top-0" name="uris"><%= (service_provider.redirect_uris || []).sort.join('<br>').html_safe %></p>
 
 <h2><label for="attribute_bundle">Attribute bundle:</label></h2>
-<p class="font-mono-xs margin-top-0" name="attribute_bundle"><%= (service_provider.attribute_bundle || []).sort.join(', ') %></p>
+<p class="font-mono-xs margin-top-0" name="attribute_bundle"><%= sp_attribute_bundle(service_provider) %></p>
 
 <h2><label for="active">Active</label></h2>
 <p class="font-mono-xs margin-top-0" name="active"><%= image_tag service_provider.active? ? 'img/alerts/success.svg' : 'img/alerts/error.svg',

--- a/spec/helpers/service_provider_helper_spec.rb
+++ b/spec/helpers/service_provider_helper_spec.rb
@@ -110,4 +110,26 @@ describe ServiceProviderHelper do
       expect(sp_allow_prompt_login_img_alt(false)).to eq('prompt=login disabled')
     end
   end
+
+  describe '#sp_attribute_bundle' do
+    it 'returns a comma separated string of alphabetized attributes by default' do
+      sp = instance_double(ServiceProvider, attribute_bundle: %w[first_name email])
+      expect(sp_attribute_bundle(sp)).to eq('email, first_name')
+    end
+
+    it 'returns an empty string if attribute_bundle is nil' do
+      sp = instance_double(ServiceProvider, attribute_bundle: nil)
+      expect(sp_attribute_bundle(sp)).to eq('')
+    end
+
+    it 'returns an empty string if attribute_bundle is empty' do
+      sp = instance_double(ServiceProvider, attribute_bundle: [])
+      expect(sp_attribute_bundle(sp)).to eq('')
+    end
+
+    it 'filters out invalid attributes' do
+      sp = instance_double(ServiceProvider, attribute_bundle: %w[first_name middle_name email])
+      expect(sp_attribute_bundle(sp)).to eq('email, first_name')
+    end
+  end
 end


### PR DESCRIPTION
Resolves LG-4072

Add ServiceProviderHelper#sp_attribute_bundle to filter out invalid attributes from the show view