### PR TITLE
Fix the setup:script

### DIFF
--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -3,15 +3,17 @@ if Rails.env.development? || Rails.env.test?
 
   namespace :dev do
     desc 'Sample data for local development environment'
-    task prime: 'db:setup' do
+    task prime: 'db:reset' do
       include FactoryBot::Syntax::Methods
 
       user = create(:user, email: 'user@example.com')
 
       issuer = 'urn:gov:gsa:SAML:2.0.profiles:sp:sso:GSA:identity-idp-local'
+
       create(:service_provider,
              user: user,
              issuer: issuer,
+             agency: Agency.find_by(name: 'General Services Administration'),
              friendly_name: Rails.application.config.app_name,
              description: 'user friendly login.gov dashboard',
              metadata_url: "http://localhost:3001/api/service_providers/#{issuer}",


### PR DESCRIPTION
**Why**: So the `make setup` works as expected

**How**: The dev:prime task was having issues with a foreign key constraint on the agencies table. This commit avoids that by using an agency that is added by the agency seeder.