### PR TITLE
[LG-4224] Ensure that PaperTrail tracks user management events

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -7,9 +7,8 @@ class Team < ApplicationRecord
 
   has_many :service_providers, dependent: :nullify, foreign_key: 'group_id',
                                inverse_of: :team
-  has_many :user_teams, dependent: :nullify, foreign_key: 'group_id',
-                        inverse_of: :team
-  has_many :users, through: :user_teams
+  has_many :user_teams, foreign_key: 'group_id', inverse_of: :team
+  has_many :users, dependent: :destroy, through: :user_teams
 
   validates :name, presence: true, uniqueness: true
 

--- a/spec/features/manage_users_spec.rb
+++ b/spec/features/manage_users_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 feature 'manage users', :js do
-  scenario 'adding and removing users by email address' do
+  scenario 'adding and removing users by email address', versioning: true do
     team = create(:team)
     user = create(:user, teams: [team])
     user_to_remove = create(:user, teams: [team])
@@ -30,6 +30,8 @@ feature 'manage users', :js do
     expect(team_member_emails).to include(user.email)
     expect(team_member_emails).to include(email_to_add)
     expect(team_member_emails).to_not include(user_to_remove.email)
+    # auditing!
+    expect(PaperTrail::Version.where(event: 'destroy', item_type: 'UserTeam').count).to eq(1)
   end
 
   scenario 'adding a user with an invalid email address renders an error' do


### PR DESCRIPTION
Resolves LG-4224

Even though the join records were being destroyed when removing a user
from a team, PaperTrail wasn't being triggered and no version was being
saved. This commit adds `dependent: :destroy` to the `has_many :users`
association for Teams, which properly triggers the PaperTrail callback.