### PR TITLE
Stop using env vars to configure rack timeout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'pg'
 gem 'pry-rails'
 gem 'pundit', '>= 2.1.0'
 gem 'rack-canonical-host'
+gem 'rack-timeout', require: false
 gem 'rails', '~> 6.1.3'
 gem 'recipient_interceptor'
 gem 'responders', '~> 3.0', '>= 3.0.1'
@@ -90,7 +91,6 @@ group :test do
 end
 
 group :production do
-  gem 'rack-timeout'
   gem 'rails_serve_static_assets'
 end
 

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -1,12 +1,6 @@
 # These settings are common across environments, but may be overridden
 # in any particular environment
 
-# How long (in seconds) to wait for requests before dropping them (via the rack_timeout gem).
-# Note that the key name must be capitalized because the gem looks for
-# ENV['RACK_TIMEOUT_SERVICE_TIMEOUT'], and AppConfig does not automatically make lowercase keys
-# available to ENV as uppercase keys.
-RACK_TIMEOUT_SERVICE_TIMEOUT: '15'
-
 aws_region: us-west-2
 aws_logo_bucket: changeme
 certificate_expiration_warning_period: '60'
@@ -16,6 +10,7 @@ idp_sp_url: changeme
 logo_upload_enabled: 'false'
 mailer_domain: changeme
 newrelic_license_key: changeme
+rack_timeout_service_timeout_seconds: '15'
 saml_sp_issuer: changeme
 saml_sp_private_key: changeme
 saml_sp_private_key_password: changeme

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,0 +1,12 @@
+require 'rack/timeout/base'
+
+Rails.application.config.middleware.insert_before(
+  Rack::Runtime,
+  Rack::Timeout,
+  service_timeout: Figaro.env.rack_timeout_service_timeout_seconds.to_i,
+)
+
+if Rails.env.development?
+  Rails.logger.info 'Disabling Rack::Timeout Logging'
+  Rack::Timeout::Logger.disable
+end


### PR DESCRIPTION
**Why**: So that the configuration for rack-timeout matches the configuration in the IDP and in PKI