### PR TITLE
Don't invoke Deploy::Activate in bin/activate

### DIFF
--- a/bin/activate
+++ b/bin/activate
@@ -1,5 +1,3 @@
 #!/usr/bin/env ruby
 
-load File.expand_path('../lib/deploy/activate.rb', File.dirname(__FILE__))
-
-Deploy::Activate.new.run
+echo 'bin/activate is a noop and can be removed'


### PR DESCRIPTION
**Why**: It was removed in a previous commit