### PR TITLE
Add AWS region to EventBridge client

### DIFF
--- a/app/services/risc_destination_updater.rb
+++ b/app/services/risc_destination_updater.rb
@@ -52,6 +52,6 @@ class RiscDestinationUpdater
   end
 
   def eventbridge_client
-    @eventbridge_client ||= Aws::EventBridge::Client.new(region: IdentiyConfig.store.aws_region)
+    @eventbridge_client ||= Aws::EventBridge::Client.new(region: IdentityConfig.store.aws_region)
   end
 end

--- a/app/services/risc_destination_updater.rb
+++ b/app/services/risc_destination_updater.rb
@@ -52,6 +52,6 @@ class RiscDestinationUpdater
   end
 
   def eventbridge_client
-    @eventbridge_client ||= Aws::EventBridge::Client.new
+    @eventbridge_client ||= Aws::EventBridge::Client.new(region: IdentiyConfig.store.aws_region)
   end
 end


### PR DESCRIPTION
Turns out this was needed after all (tried this in the console just now)