### PR TITLE
Update RiscDestinationUpdater to handle more AWS object graph

### DIFF
--- a/app/services/risc_destination_updater.rb
+++ b/app/services/risc_destination_updater.rb
@@ -9,18 +9,123 @@ class RiscDestinationUpdater
 
   def update
     if service_provider.push_notification_url.present?
-      if api_destination_exists?
-        eventbridge_client.update_api_destination(api_destination_attributes)
-      else
-        eventbridge_client.create_api_destination(api_destination_attributes)
-      end
+      put_rule
+      connection_arn = create_or_update_connnection
+      api_destination_arn = create_or_update_api_destination(connection_arn)
+      put_targets(api_destination_arn)
     else
       remove
     end
   end
 
   def remove
+    remove_rule if rule_exists?
     eventbridge_client.delete_api_destination(name: api_destination_name) if api_destination_exists?
+    eventbridge_client.delete_connection(name: connection_name) if connection_exists?
+  end
+
+  def connection_name
+    "#{Identity::Hostdata.env}-risc-connection-#{service_provider.issuer}"
+  end
+
+  def rule_name
+    "#{Identity::Hostdata.env}-risc-rule-#{service_provider.issuer}"
+  end
+
+  def api_destination_name
+    "#{Identity::Hostdata.env}-risc-destination-#{service_provider.issuer}"
+  end
+
+  def target_id
+    "#{Identity::Hostdata.env}-risc-target-#{service_provider.issuer}"
+  end
+
+  def event_bus_name
+    # Matches value managed by Terraform
+    "#{Identity::Hostdata.env}-risc-notifications"
+  end
+
+  def rule_exists?
+    eventbridge_client.list_rules(
+      name_prefix: rule_name,
+      event_bus_name: event_bus_name,
+      limit: 1,
+    ).rules.first.present?
+  end
+
+  def put_rule
+    eventbridge_client.put_rule(
+      name: rule_name,
+      event_pattern: {
+        account: [aws_account_id],
+        source: [service_provider.issuer],
+      }.to_json,
+      state: 'ENABLED',
+      description: "Rule for for #{service_provider.friendly_name}",
+      event_bus_name: event_bus_name,
+    )
+  end
+
+  def put_targets(api_destination_arn)
+    eventbridge_client.put_targets(
+      rule: rule_name,
+      event_bus_name: event_bus_name,
+      targets: [
+        id: target_id,
+        arn: api_destination_arn,
+        input_path: '$.detail',
+        http_parameters: {
+          header_parameters: {
+            'Content-Type' => 'application/secevent+jwt',
+          },
+        },
+      ],
+    )
+  end
+
+  def remove_rule
+    target_ids = eventbridge_client.list_targets_by_rule(
+      rule: rule_name,
+      event_bus_name: event_bus_name,
+    ).targets.map(&:id)
+
+    # Must remove targets before we can delete a rule
+    eventbridge_client.remove_targets(
+      rule: rule_name,
+      event_bus_name: event_bus_name,
+      ids: target_ids,
+    )
+
+    eventbridge_client.delete_rule(name: rule_name, force: true)
+  end
+
+  def connection_exists?
+    eventbridge_client.list_connections(
+      name_prefix: connection_name,
+      limit: 1,
+    ).connections.first.present?
+  end
+
+  # @return [String] connection ARN
+  def create_or_update_connnection
+    connection_attrs = {
+      name: connection_name,
+      authorization_type: 'API_KEY',
+      auth_parameters: {
+        api_key_auth_parameters: {
+          api_key_name: 'X-Login-Gov-Source',
+          api_key_value: 'EventBridge',
+        },
+      },
+    }
+
+    response = if connection_exists?
+      eventbridge_client.update_connection(connection_attrs)
+    else
+      eventbridge_client.create_connection(connection_attrs)
+    end
+
+    response.connection_arn
   end
 
   def api_destination_exists?
@@ -30,25 +135,34 @@ class RiscDestinationUpdater
     ).api_destinations.first.present?
   end
 
-  def api_destination_name
-    "#{Identity::Hostdata.env}-risc-#{service_provider.issuer}"
-  end
-
-  def api_destination_attributes
-    {
+  # @return [String] api destination ARN
+  def create_or_update_api_destination(connection_arn)
+    api_destination_attrs = {
       name: api_destination_name,
       connection_arn: connection_arn,
       description: "Destination for #{service_provider.friendly_name}",
       invocation_endpoint: service_provider.push_notification_url,
       http_method: 'POST',
     }
+
+    response = if api_destination_exists?
+      eventbridge_client.update_api_destination(api_destination_attrs)
+    else
+      eventbridge_client.create_api_destination(api_destination_attrs)
+    end
+
+    response.api_destination_arn
   end
 
-  def connection_arn
-    eventbridge_client.list_connections(
-      name_prefix: "#{Identity::Hostdata.env}-risc",
-      limit: 1,
-    ).connections.first.connection_arn
+  def aws_account_id
+    Identity::Hostdata::EC2.load.account_id
+  rescue Net::OpenTimeout,
+         Errno::EHOSTDOWN,
+         Errno::EHOSTUNREACH,
+         WebMock::NetConnectNotAllowedError => e
+    raise e if Identity::Hostdata.in_datacenter?
+
+    '123456'
   end
 
   def eventbridge_client

--- a/spec/services/risc_destination_updater_spec.rb
+++ b/spec/services/risc_destination_updater_spec.rb
@@ -59,6 +59,33 @@ RSpec.describe RiscDestinationUpdater do
     end
   end
 
+  shared_examples_for 'removes_rules' do
+    context 'when a rule does not exist for the SP' do
+      let(:existing_rules) { [] }
+
+      it 'no-ops' do
+        expect(updater.eventbridge_client).to_not receive(:delete_rule)
+
+        subject
+      end
+    end
+
+    context 'when a rule exists for the SP' do
+      let(:existing_rules) do
+        [
+          { name: "int-risc-rule-#{service_provider.issuer}" },
+        ]
+      end
+
+      it 'removes the API destination' do
+        expect(updater.eventbridge_client).to receive(:delete_rule).
+          with(name: "int-risc-rule-#{service_provider.issuer}", force: true).and_call_original
+
+        subject
+      end
+    end
+  end
+
   describe '#update' do
     subject(:update) { updater.update }
 
@@ -106,6 +133,7 @@ RSpec.describe RiscDestinationUpdater do
       let(:push_notification_url) { nil }
 
       it_behaves_like 'removes_api_destination'
+      it_behaves_like 'removes_rules'
     end
   end
 
@@ -113,6 +141,7 @@ RSpec.describe RiscDestinationUpdater do
     subject(:remove) { updater.remove }
 
     it_behaves_like 'removes_api_destination'
+    it_behaves_like 'removes_rules'
   end
 
   describe '#connection_name' do

--- a/spec/services/risc_destination_updater_spec.rb
+++ b/spec/services/risc_destination_updater_spec.rb
@@ -18,12 +18,19 @@ RSpec.describe RiscDestinationUpdater do
 
     Aws.config[:eventbridge] = {
       stub_responses: {
-        list_connections: { connections:[ { connection_arn: connection_arn } ] },
+        list_connections: { connections: existing_connections },
+        create_connection: { connection_arn: connection_arn },
+        update_connection: { connection_arn: connection_arn },
         list_api_destinations: { api_destinations: existing_api_desinations },
+        list_rules: { rules: existing_rules },
+        list_targets_by_rule: { targets: existing_targets },
       },
     }
   end
+  let(:existing_connections) { [] }
   let(:existing_api_desinations) { [] }
+  let(:existing_rules) { [] }
+  let(:existing_targets) { [] }
 
   shared_examples_for 'removes_api_destination' do
     context 'when an API destination does not exist for the SP' do
@@ -45,7 +52,7 @@ RSpec.describe RiscDestinationUpdater do
 
       it 'removes the API destination' do
         expect(updater.eventbridge_client).to receive(:delete_api_destination).
-          with(name: "int-risc-#{service_provider.issuer}").and_call_original
+          with(name: "int-risc-destination-#{service_provider.issuer}").and_call_original
 
         subject
       end
@@ -62,7 +69,7 @@ RSpec.describe RiscDestinationUpdater do
         it 'creates an API destination' do
           expect(updater.eventbridge_client).to receive(:create_api_destination).
             with(
-              name: "int-risc-#{service_provider.issuer}",
+              name: "int-risc-destination-#{service_provider.issuer}",
               connection_arn: connection_arn,
               description: 'Destination for My Cool App',
               invocation_endpoint: push_notification_url,
@@ -83,7 +90,7 @@ RSpec.describe RiscDestinationUpdater do
         it 'updates the existing API destination' do
           expect(updater.eventbridge_client).to receive(:update_api_destination).
             with(
-              name: "int-risc-#{service_provider.issuer}",
+              name: "int-risc-destination-#{service_provider.issuer}",
               connection_arn: connection_arn,
               description: 'Destination for My Cool App',
               invocation_endpoint: push_notification_url,
@@ -108,9 +115,33 @@ RSpec.describe RiscDestinationUpdater do
     it_behaves_like 'removes_api_destination'
   end
 
+  describe '#connection_name' do
+    it 'includes the ENV and the issuer' do
+      expect(updater.connection_name).to eq("int-risc-connection-#{service_provider.issuer}")
+    end
+  end
+
+  describe '#rule_name' do
+    it 'includes the ENV and the issuer' do
+      expect(updater.rule_name).to eq("int-risc-rule-#{service_provider.issuer}")
+    end
+  end
+
   describe '#api_destination_name' do
     it 'includes the ENV and the issuer' do
-      expect(updater.api_destination_name).to eq("int-risc-#{service_provider.issuer}")
+      expect(updater.api_destination_name).to eq("int-risc-destination-#{service_provider.issuer}")
+    end
+  end
+
+  describe '#target_id' do
+    it 'includes the ENV and the issuer' do
+      expect(updater.target_id).to eq("int-risc-target-#{service_provider.issuer}")
+    end
+  end
+
+  describe '#event_bus_name' do
+    it 'includes the ENV' do
+      expect(updater.event_bus_name).to eq('int-risc-notifications')
     end
   end
 end


### PR DESCRIPTION
Here's my mental model of what I'm trying to create (the boxes in blue)

![RISC EventBridge Architecture (1)](https://user-images.githubusercontent.com/458784/120857432-1e2b6b80-c536-11eb-8dfe-a285a96db235.jpg)

I went a lot lighter on the test coverage this time because at the end of the day it's all stubbed, and more tests won't catch misconfigurations