### PR TITLE
[LG-4666] Add email NameID format config to SPs

### DIFF
--- a/app/controllers/service_providers_controller.rb
+++ b/app/controllers/service_providers_controller.rb
@@ -151,6 +151,7 @@ class ServiceProvidersController < AuthenticatedController
       help_text: {},
     ]
     permit_params << :production_issuer if current_user.admin?
+    permit_params << :email_nameid_format_allowed if current_user.admin?
     params.require(:service_provider).permit(*permit_params)
   end
 

--- a/app/helpers/service_provider_helper.rb
+++ b/app/helpers/service_provider_helper.rb
@@ -88,6 +88,11 @@ module ServiceProviderHelper
     'prompt=login disabled'
   end
 
+  def sp_email_nameid_format_allowed_img_alt(sp_email_nameid_format_allowed)
+    return 'Email NameID format allowed' if sp_email_nameid_format_allowed
+    'Email NameID format prohibited'
+  end
+
   def sp_attribute_bundle(service_provider)
     return '' unless service_provider.attribute_bundle.present?
 

--- a/app/views/service_providers/_email_nameid_format_allowed.html.erb
+++ b/app/views/service_providers/_email_nameid_format_allowed.html.erb
@@ -1,0 +1,7 @@
+<h2><label for="email_nameid_format_allowed">Email NameID Format Allowed</label></h2>
+<p class="font-mono-xs margin-top-0" name="email_nameid_format_allowed">
+<%= image_tag service_provider.email_nameid_format_allowed? ? 'img/alerts/success.svg' : 'img/alerts/error.svg',
+              height: '27', width: '27',
+              class: 'margin-bottom-neg-105',
+              alt: sp_email_nameid_format_allowed_img_alt(service_provider.email_nameid_format_allowed?) %>
+</p>

--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -99,6 +99,20 @@
         </li>
       </ul>
     </fieldset>
+
+    <%# email_nameid_format_allowed checkbox %>
+    <fieldset class="usa-fieldset">
+      <legend class="usa-sr-only">Allow email NameID Format</legend>
+      <%= form.label :email_nameid_format_allowed,
+                      label: 'Allow Email NameID Format',
+                      class: 'usa-label' %>
+      <ul class="usa-input-list">
+        <li>
+          <%= form.check_box :email_nameid_format_allowed, class: 'usa-checkbox__input' %>
+          <%= form.label :email_nameid_format_allowed, 'Enabled', class: 'usa-checkbox__label' %>
+        </li>
+      </ul>
+    </fieldset>
   <% end %>
 
   <%# Temp hack to allow feature in dev but not int for testing %>

--- a/app/views/service_providers/show.html.erb
+++ b/app/views/service_providers/show.html.erb
@@ -31,6 +31,7 @@
   <h2><label for="production_issuer">Production Issuer:</label></h2>
   <p class="font-mono-xs margin-top-0" name="production_issuer"><%=  service_provider.production_issuer %></p>
   <%= render partial: 'allow_prompt_login', locals: { service_provider: service_provider } %>
+  <%= render partial: 'email_nameid_format_allowed', locals: { service_provider: service_provider } %>
 <% elsif service_provider.allow_prompt_login? %>
   <%= render partial: 'allow_prompt_login', locals: { service_provider: service_provider } %>
 <% end %>

--- a/db/migrate/20210614190137_add_email_name_id_format_to_service_providers.rb
+++ b/db/migrate/20210614190137_add_email_name_id_format_to_service_providers.rb
@@ -1,0 +1,5 @@
+class AddEmailNameIdFormatToServiceProviders < ActiveRecord::Migration[6.1]
+  def change
+    add_column :service_providers, :email_nameid_format_allowed, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_12_181322) do
+ActiveRecord::Schema.define(version: 2021_06_14_190137) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -117,6 +117,7 @@ ActiveRecord::Schema.define(version: 2021_04_12_181322) do
     t.boolean "allow_prompt_login", default: false
     t.integer "default_aal"
     t.string "certs", array: true
+    t.boolean "email_nameid_format_allowed", default: false
     t.index ["group_id"], name: "index_service_providers_on_group_id"
     t.index ["issuer"], name: "index_service_providers_on_issuer", unique: true
   end

--- a/spec/features/service_providers_spec.rb
+++ b/spec/features/service_providers_spec.rb
@@ -120,6 +120,16 @@ feature 'Service Providers CRUD' do
       expect(page).not_to have_css('input#service_provider_allow_prompt_login')
     end
 
+    scenario 'cannot edit email_nameid_format_allowed' do
+      user = create(:user, :with_teams)
+      service_provider = create(:service_provider, :saml, :with_users_team, user: user)
+      login_as(user)
+
+      visit edit_service_provider_path(service_provider)
+
+      expect(page).not_to have_css('input#service_provider_email_nameid_format_allowed')
+    end
+
     # Poltergeist is attempting to click at coordinates [-16333, 22.5] when
     # choosing the protocol in the following four scenarios.
     # rubocop:disable Layout/LineLength
@@ -224,6 +234,18 @@ feature 'Service Providers CRUD' do
 
       visit edit_service_provider_path(sp)
       check 'service_provider_allow_prompt_login'
+      click_on 'Update'
+
+      expect(page).to have_content('Success')
+    end
+
+    scenario 'can enable email NameID format for a service provider' do
+      admin = create(:admin)
+      sp = create(:service_provider, :with_team)
+      login_as(admin)
+
+      visit edit_service_provider_path(sp)
+      check 'service_provider_email_nameid_format_allowed'
       click_on 'Update'
 
       expect(page).to have_content('Success')


### PR DESCRIPTION
Resolves LG-4666

* Add email_nameid_format_allowed column to service_providers table
* Update strong params and add controls to edit and view the attribute
  if you're an admin
* Add basic feature specs