### PR TITLE
[LG-4446] Add PKCE option to service provider form

### DIFF
--- a/app/javascript/app/service-provider-form.js
+++ b/app/javascript/app/service-provider-form.js
@@ -10,7 +10,11 @@ $(function(){
 
   var toggle_form_fields = function(id_protocol){
     switch(id_protocol){
-      case 'openid_connect':
+      case 'openid_connect_private_key_jwt':
+        $('.saml-fields').hide();
+        $('.oidc-fields').show();
+        break;
+      case 'openid_connect_pkce':
         $('.saml-fields').hide();
         $('.oidc-fields').show();
         break;
@@ -24,39 +28,14 @@ $(function(){
     }
   }
 
-  var issuer_protocol_name = function(id_protocol){
-    switch(id_protocol){
-      case 'openid_connect':
-        return 'openidconnect';
-      case 'saml':
-        return 'SAML:2.0';
-      default:
-        return "";
-    }
-  }
-
   var id_protocol = function(){
     return $('input[name="service_provider[identity_protocol]"]:checked').val();
-  }
-
-  var update_issuer = function() {
-    var protocol = issuer_protocol_name(id_protocol());
-    var department = $('#service_provider_issuer_department').val();
-    var app = $('#service_provider_issuer_app').val();
-
-    var issuer_string = SERVICE_PROVIDER_ISSUER_TEMPLATE
-      .replace('{protocol}', protocol)
-      .replace('{department}', department)
-      .replace('{app}', app);
-
-    $('#service_provider_issuer').val(issuer_string);
   }
 
   toggle_form_fields(id_protocol());
 
   $('input[name="service_provider[identity_protocol]"]').click(function(){
     toggle_form_fields(id_protocol());
-    // update_issuer();
   });
 
   // $('input[name="service_provider[issuer_department]"]').keyup(update_issuer);

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -19,7 +19,7 @@ class ServiceProvider < ApplicationRecord
   validate :certs_are_pems
 
   enum block_encryption: { 'none' => 0, 'aes256-cbc' => 1 }, _suffix: 'encryption'
-  enum identity_protocol: { openid_connect: 0, saml: 1 }
+  enum identity_protocol: { openid_connect_private_key_jwt: 0, openid_connect_pkce: 2, saml: 1 }
 
   before_validation(on: %i[create update]) do
     self.attribute_bundle = attribute_bundle.reject(&:blank?) if attribute_bundle.present?
@@ -96,6 +96,10 @@ class ServiceProvider < ApplicationRecord
     @certificates = nil
 
     serial
+  end
+
+  def oidc?
+    openid_connect_pkce? || openid_connect_private_key_jwt?
   end
 
   private

--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -132,6 +132,7 @@
     <p>
       Your public certificate (or certificates), which contains your public key.
       Needed for OpenID Connect (when using <i>private_key_jwt</i>) and for SAML.
+      Optional for OIDC PKCE.
     </p>
 
 

--- a/app/views/service_providers/show.html.erb
+++ b/app/views/service_providers/show.html.erb
@@ -90,10 +90,9 @@
 <h2><label for="push_notification_url">Push Notification URL:</label></h2>
 <p class="font-mono-xs margin-top-0" name="push_notification_url"><%= service_provider.push_notification_url %></p>
 
-    <% if service_provider.identity_protocol == 'openid_connect' %>
+    <% if service_provider.oidc? %>
         <h2><label for="uris">Redirect URIs</label></h2>
-    <% end %>
-    <% if service_provider.identity_protocol == 'saml' %>
+    <% else # SAML %>
         <h2><label for="uris">Additional Redirect URIs</label></h2>
     <% end %>
     <p class="font-mono-xs margin-top-0" name="uris"><%= (service_provider.redirect_uris || []).sort.join('<br>').html_safe %></p>

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -18,4 +18,6 @@
 ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym 'OpenID'
   inflect.acronym 'SAML'
+  inflect.acronym 'PKCE'
+  inflect.acronym 'JWT'
 end

--- a/spec/models/service_provider_spec.rb
+++ b/spec/models/service_provider_spec.rb
@@ -333,4 +333,19 @@ describe ServiceProvider do
       end
     end
   end
+
+  describe '#oidc?' do
+    it 'returns false for SAML integrations' do
+      sp = build(:service_provider, identity_protocol: 'saml')
+      expect(!sp.oidc?)
+    end
+    it 'returns true for OIDC private_key_jwt integrations' do
+      sp = build(:service_provider, identity_protocol: 'openid_connect_private_key_jwt')
+      expect(sp.oidc?)
+    end
+    it 'returns true for OIDC PKCE integrations' do
+      sp = build(:service_provider, identity_protocol: 'openid_connect_pkce')
+      expect(sp.oidc?)
+    end
+  end
 end


### PR DESCRIPTION
Resolves LG-4446

* Adds additional enumerated option for protocol and updates the generic
  OIDC option to specify private_key_jwt.
* Update JS to appropriately hide the certificate fields when OIDC PKCE
  is selected
* Add necessary acronyms to ActiveSupport::Inflector