### PR TITLE
Update EventBridge names to fit within 64 character limit

### DIFF
--- a/app/services/risc_destination_updater.rb
+++ b/app/services/risc_destination_updater.rb
@@ -25,7 +25,7 @@ class RiscDestinationUpdater
   end
 
   def issuer_slug
-    @issuer_slug ||= service_provider.issuer.gsub(/[^.\-_A-Za-z0-9]/, '_')
+    "issuer-#{service_provider.id}"
   end
 
   def connection_name

--- a/spec/services/risc_destination_updater_spec.rb
+++ b/spec/services/risc_destination_updater_spec.rb
@@ -7,11 +7,12 @@ RSpec.describe RiscDestinationUpdater do
   let(:service_provider) do
     build(
       :service_provider,
+      id: SecureRandom.random_number(1000),
       friendly_name: 'My Cool App',
       push_notification_url: push_notification_url,
     )
   end
-  let(:service_provider_slug) { service_provider.issuer.tr(':', '_') }
+  let(:service_provider_slug) { "issuer-#{service_provider.id}" }
   let(:connection_arn) { SecureRandom.hex }
 
   before do
@@ -194,10 +195,10 @@ RSpec.describe RiscDestinationUpdater do
   end
 
   describe '#issuer_slug' do
-    let(:service_provider) { build(:service_provider, issuer: 'a,bc:def!ghi %') }
+    let(:service_provider) { build(:service_provider, id: SecureRandom.random_number(1000)) }
 
-    it 'removes illegal characters and replaces them with _' do
-      expect(updater.issuer_slug).to eq('a_bc_def_ghi__')
+    it 'is the issuer DB id' do
+      expect(updater.issuer_slug).to eq("issuer-#{service_provider.id}")
     end
   end
 end


### PR DESCRIPTION
Ran into another issue testing in my env

I wish we had another stable identifier for these besides DB ID, but this is what we have for now

Luckily the IDP does not need to reference these IDs (because they'd be different on the IDP side anyways), they just need to be consistent from the side of whatever manages these, which is Dashboard vs Dashboard.