### PR TITLE
LG-5014 - Dynamically show/hide IAL/Protocol options only

### DIFF
--- a/app/javascript/app/service-provider-form.js
+++ b/app/javascript/app/service-provider-form.js
@@ -99,6 +99,7 @@ $(function(){
 
   redirectURI.click(() => $(".service_provider_redirect_uris input:last-child")
       .clone()
+      .val('')
       .appendTo(".service_provider_redirect_uris")
   );
 

--- a/app/javascript/app/service-provider-form.js
+++ b/app/javascript/app/service-provider-form.js
@@ -4,19 +4,17 @@ $(function(){
   }
 
   // Selectors
-  const samlFields = $('.saml-fields');
-  const oidcFields = $('.oidc-fields');
   const idProtocol = $('input[name="service_provider[identity_protocol]"]');
   const ialLevel = $('#service_provider_ial');
+  const samlFields = $('.saml-fields');
+  const oidcFields = $('.oidc-fields');
   const ialAttributes = $('.ial-attr-wrapper')
-  const failureToProofInput = $('.service_provider_failure_to_proof_url');
-  const redirectURI = $("#add-redirect-uri-field");
-  const pemInputMessage = $('.js-pem-input-error-message');
   const fileInput = $('.input-file');
   const filePreview = $('.input-preview');
   const pemInput = $('.js-pem-input');
-
-  ialAttributes.each((idx, el) => console.log(el))
+  const pemInputMessage = $('.js-pem-input-error-message');
+  const redirectURI = $("#add-redirect-uri-field");
+  const failureToProofInput = $('.service_provider_failure_to_proof_url');
 
   // Functions
   const toggleFormFields = (idProtocol) => {
@@ -37,6 +35,7 @@ $(function(){
   }
 
   const toggleIALOptions = (ial) => {
+    ialAttributes.each((idx, el) => console.log(el))
     switch(ial) {
       case '1':
         failureToProofInput.hide();

--- a/app/javascript/app/service-provider-form.js
+++ b/app/javascript/app/service-provider-form.js
@@ -35,7 +35,6 @@ $(function(){
   }
 
   const toggleIALOptions = (ial) => {
-    ialAttributes.each((idx, el) => console.log(el))
     switch(ial) {
       case '1':
         failureToProofInput.hide();

--- a/app/javascript/app/service-provider-form.js
+++ b/app/javascript/app/service-provider-form.js
@@ -1,5 +1,5 @@
-$(function(){
-  if(!$('.service-provider-form').length){
+$(function () {
+  if (!$('.service-provider-form').length) {
     return;
   }
 
@@ -8,19 +8,19 @@ $(function(){
   const ialLevel = $('#service_provider_ial');
   const samlFields = $('.saml-fields');
   const oidcFields = $('.oidc-fields');
-  const ialAttributesCheckboxes = $('.ial-attr-wrapper')
+  const ialAttributesCheckboxes = $('.ial-attr-wrapper');
+  const fileContainer = $('#certificate-container');
   const fileInput = $('.input-file');
-  const filePreview = $('.input-preview');
-  const pemInput = $('.js-pem-input');
   const pemInputMessage = $('.js-pem-input-error-message');
-  const redirectURI = $("#add-redirect-uri-field");
+  const pemInput = $('.js-pem-input');
+  const redirectURI = $('#add-redirect-uri-field');
   const failureToProofURL = $('.service_provider_failure_to_proof_url');
 
   const ia1Attributes = ['email', 'x509_subject', 'x509_presented'];
 
   // Functions
   const toggleFormFields = (idProtocol) => {
-    switch(idProtocol) {
+    switch (idProtocol) {
       case 'openid_connect_private_key_jwt':
       case 'openid_connect_pkce':
         toggleOIDCOptions();
@@ -32,10 +32,10 @@ $(function(){
         samlFields.show();
         oidcFields.show();
     }
-  }
+  };
 
   const toggleIALOptions = (ial) => {
-    switch(ial) {
+    switch (ial) {
       case '1':
         failureToProofURL.hide();
         failureToProofURL.find('input').val('');
@@ -49,7 +49,7 @@ $(function(){
         failureToProofURL.show();
         toggleIAL2Options();
     }
-  }
+  };
 
   const toggleIAL1Options = () => {
     ialAttributesCheckboxes.each((idx, attr) => {
@@ -59,60 +59,67 @@ $(function(){
         $(attr).hide();
         element.prop('checked', false);
       }
-    })
-  }
+    });
+  };
 
   const toggleIAL2Options = () => {
     ialAttributesCheckboxes.each((idx, attr) => $(attr).show());
-  }
+  };
 
   const toggleSAMLOptions = () => {
     samlFields.show();
     oidcFields.hide();
 
-    oidcFields.find('input, textarea')
-      .val('')
-      .prop('checked', false)
-      .prop('selected', false);
-  }
+    resetFields(oidcFields);
+  };
 
   const toggleOIDCOptions = () => {
     oidcFields.show();
     samlFields.hide();
 
-    samlFields.find('input, textarea')
-        .val('')
-        .prop('checked', false)
-        .prop('selected', false);
-  }
+    resetFields(samlFields);
+  };
 
-  const setPemError = message => pemInputMessage.innerText = message;
+  const resetFields = (fields) => {
+    fields
+      .find('input, textarea')
+      .val('')
+      .prop('checked', false)
+      .prop('selected', false);
+  };
+
+  const setPemError = (message) => (pemInputMessage[0].textContent = message);
 
   // Page initialization
   toggleFormFields(idProtocol.val());
   toggleIALOptions(ialLevel.val());
 
   // Event triggers
-  idProtocol.change(evt => toggleFormFields(evt.target.value));
+  idProtocol.change((evt) => toggleFormFields(evt.target.value));
 
-  ialLevel.change(evt => toggleIALOptions(evt.target.value));
+  ialLevel.change((evt) => toggleIALOptions(evt.target.value));
 
-  redirectURI.click(() => $(".service_provider_redirect_uris input:last-child")
-      .clone()
-      .val('')
-      .appendTo(".service_provider_redirect_uris")
+  redirectURI.click(() =>
+      $('.service_provider_redirect_uris input:last-child')
+          .clone()
+          .val('')
+          .appendTo('.service_provider_redirect_uris')
   );
 
-  // This will need to change if we start uploading more files, e.g. certs, etc.
-  fileInput.change(() => {
-    const logo_file = filePreview.files[0];
-    filePreview.textContent = logo_file.name;
+  fileContainer.on('change', fileInput, () => {
+    // Handles a single file currently, used for logos
+    const logoFile = fileInput[0].files[0];
+    const filePreview = $('.input-preview');
+
+    filePreview.textContent = logoFile.name;
   });
 
-  pemInput.change((event) => {
-    const file = event.target.files[0];
+  fileContainer.on('change', pemInput, () => {
+    // Handles a single certificate file currently
+    const file = pemInput[0].files[0];
+    const pemFilename = $('.js-pem-file-name');
 
-    $('.js-pem-file-name').innerText = file ? file.name : null;
+    pemFilename[0].textContent = file ? file.name : null;
 
     if (file && file.text) {
       file.text().then((content) => {

--- a/app/javascript/app/service-provider-form.js
+++ b/app/javascript/app/service-provider-form.js
@@ -1,89 +1,93 @@
-// Note: We've temporarily disabled validation of the issuer. Calls to
-// `update_issuer` have been commented out.
-
-var SERVICE_PROVIDER_ISSUER_TEMPLATE = 'urn:gov:gsa:{protocol}.profiles:sp:sso:{department}:{app}'
-
 $(function(){
   if(!$('.service-provider-form').length){
     return;
   }
 
-  var toggle_form_fields = function(id_protocol){
-    switch(id_protocol){
+  // Selectors
+  const samlFields = $('.saml-fields');
+  const oidcFields = $('.oidc-fields');
+  const idProtocol = $('input[name="service_provider[identity_protocol]"]');
+  const ialLevel = $('#service_provider_ial');
+  const ialAttributes = $('.ial-attr-wrapper')
+  const failureToProofInput = $('.service_provider_failure_to_proof_url');
+  const redirectURI = $("#add-redirect-uri-field");
+  const pemInputMessage = $('.js-pem-input-error-message');
+  const fileInput = $('.input-file');
+  const filePreview = $('.input-preview');
+  const pemInput = $('.js-pem-input');
+
+  ialAttributes.each((idx, el) => console.log(el))
+
+  // Functions
+  const toggleFormFields = (idProtocol) => {
+    switch(idProtocol) {
       case 'openid_connect_private_key_jwt':
-        $('.saml-fields').hide();
-        $('.oidc-fields').show();
-        break;
       case 'openid_connect_pkce':
-        $('.saml-fields').hide();
-        $('.oidc-fields').show();
+        samlFields.hide();
+        oidcFields.show();
         break;
       case 'saml':
-        $('.saml-fields').show();
-        $('.oidc-fields').hide();
+        samlFields.show();
+        oidcFields.hide();
         break;
       default:
-        $('.saml-fields').show();
-        $('.oidc-fields').show();
+        samlFields.show();
+        oidcFields.show();
     }
   }
 
-  var id_protocol = function(){
-    return $('input[name="service_provider[identity_protocol]"]:checked').val();
+  const toggleIALOptions = (ial) => {
+    switch(ial) {
+      case '1':
+        failureToProofInput.hide();
+        break;
+      case '2':
+        failureToProofInput.show();
+        break;
+      default:
+        failureToProofInput.show();
+    }
   }
 
-  toggle_form_fields(id_protocol());
+  const setPemError = message => pemInputMessage.innerText = message;
 
-  $('input[name="service_provider[identity_protocol]"]').click(function(){
-    toggle_form_fields(id_protocol());
-  });
+  // Page initialization
+  toggleFormFields(idProtocol.val());
+  toggleIALOptions(ialLevel.val());
 
-  // $('input[name="service_provider[issuer_department]"]').keyup(update_issuer);
-  // $('input[name="service_provider[issuer_app]"]').keyup(update_issuer);
+  // Event triggers
+  idProtocol.change(evt => toggleFormFields(evt.target.value));
 
-  // Add another Redirect URI
-  $("#add-redirect-uri-field").click(function() {
-    $(".service_provider_redirect_uris input:last-child").clone().appendTo(".service_provider_redirect_uris");
-  });
+  ialLevel.change(evt => toggleIALOptions(evt.target.value));
+
+  redirectURI.click(() => $(".service_provider_redirect_uris input:last-child")
+      .clone()
+      .appendTo(".service_provider_redirect_uris")
+  );
 
   // This will need to change if we start uploading more files, e.g. certs, etc.
-  const input = document.querySelector('.input-file');
-  const preview = document.querySelector('.input-preview');
-  if (input) {
-    input.addEventListener('change', function () {
-      logo_file = input.files[0];
-      preview.textContent = logo_file.name;
-    });
-  }
+  fileInput.change(() => {
+    const logo_file = filePreview.files[0];
+    filePreview.textContent = logo_file.name;
+  });
 
-  /**
-   * @param {string?} message
-   */
-  function setPemError(message) {
-    var pemInputMessage = document.querySelector('.js-pem-input-error-message');
-    pemInputMessage.innerText = message;
-  }
+  pemInput.change((event) => {
+    const file = event.target.files[0];
 
-  var pemInput = document.querySelector('.js-pem-input');
-  if (pemInput) {
-    pemInput.addEventListener('change', function(event) {
-      var file = event.target.files[0];
+    $('.js-pem-file-name').innerText = file ? file.name : null;
 
-      document.querySelector('.js-pem-file-name').innerText = file ? file.name : null;
-
-      if (file && file.text) {
-        file.text().then(function(content) {
-          if (content.includes('PRIVATE')) {
-            setPemError('This is a private key, upload the public key instead');
-          } else if (!content.includes('-----BEGIN CERTIFICATE-----')) {
-            setPemError('This file does not appear to be PEM encoded');
-          } else {
-            setPemError(null);
-          }
-        });
-      } else {
-        setPemError(null);
-      }
-    });
-  }
+    if (file && file.text) {
+      file.text().then((content) => {
+        if (content.includes('PRIVATE')) {
+          setPemError('This is a private key, upload the public key instead');
+        } else if (!content.includes('-----BEGIN CERTIFICATE-----')) {
+          setPemError('This file does not appear to be PEM encoded');
+        } else {
+          setPemError(null);
+        }
+      });
+    } else {
+      setPemError(null);
+    }
+  });
 });

--- a/app/javascript/app/service-provider-form.js
+++ b/app/javascript/app/service-provider-form.js
@@ -8,25 +8,25 @@ $(function(){
   const ialLevel = $('#service_provider_ial');
   const samlFields = $('.saml-fields');
   const oidcFields = $('.oidc-fields');
-  const ialAttributes = $('.ial-attr-wrapper')
+  const ialAttributesCheckboxes = $('.ial-attr-wrapper')
   const fileInput = $('.input-file');
   const filePreview = $('.input-preview');
   const pemInput = $('.js-pem-input');
   const pemInputMessage = $('.js-pem-input-error-message');
   const redirectURI = $("#add-redirect-uri-field");
-  const failureToProofInput = $('.service_provider_failure_to_proof_url');
+  const failureToProofURL = $('.service_provider_failure_to_proof_url');
+
+  const ia1Attributes = ['email', 'x509_subject', 'x509_presented'];
 
   // Functions
   const toggleFormFields = (idProtocol) => {
     switch(idProtocol) {
       case 'openid_connect_private_key_jwt':
       case 'openid_connect_pkce':
-        samlFields.hide();
-        oidcFields.show();
+        toggleOIDCOptions();
         break;
       case 'saml':
-        samlFields.show();
-        oidcFields.hide();
+        toggleSAMLOptions();
         break;
       default:
         samlFields.show();
@@ -37,14 +37,53 @@ $(function(){
   const toggleIALOptions = (ial) => {
     switch(ial) {
       case '1':
-        failureToProofInput.hide();
+        failureToProofURL.hide();
+        failureToProofURL.find('input').val('');
+        toggleIAL1Options();
         break;
       case '2':
-        failureToProofInput.show();
+        failureToProofURL.show();
+        toggleIAL2Options();
         break;
       default:
-        failureToProofInput.show();
+        failureToProofURL.show();
+        toggleIAL2Options();
     }
+  }
+
+  const toggleIAL1Options = () => {
+    ialAttributesCheckboxes.each((idx, attr) => {
+      const element = $(attr).find('input');
+
+      if (!ia1Attributes.includes(element.val())) {
+        $(attr).hide();
+        element.prop('checked', false);
+      }
+    })
+  }
+
+  const toggleIAL2Options = () => {
+    ialAttributesCheckboxes.each((idx, attr) => $(attr).show());
+  }
+
+  const toggleSAMLOptions = () => {
+    samlFields.show();
+    oidcFields.hide();
+
+    oidcFields.find('input, textarea')
+      .val('')
+      .prop('checked', false)
+      .prop('selected', false);
+  }
+
+  const toggleOIDCOptions = () => {
+    oidcFields.show();
+    samlFields.hide();
+
+    samlFields.find('input, textarea')
+        .val('')
+        .prop('checked', false)
+        .prop('selected', false);
   }
 
   const setPemError = message => pemInputMessage.innerText = message;

--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -81,8 +81,8 @@
                                     collection_wrapper_class: 'usa-input-list',
                                     item_wrapper_tag: :li,
                                     item_wrapper_class: 'ial-attr-wrapper') do |b| %>
-      <%= b.check_box class: "usa-checkbox__input #{b.text}" %>
-      <%= b.label class: "usa-checkbox__label #{b.text}" %>
+      <%= b.check_box class: "usa-checkbox__input}" %>
+      <%= b.label class: "usa-checkbox__label" %>
     <% end %>
   </fieldset>
 

--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -65,6 +65,27 @@
                  #label_html: { class: 'usa-input-required'},
                  hint: 'Empty - MFA required + remember device is 30 days<br/>AAL2 - MFA required + remember device is 12 hours<br/>AAL3 - unphishable MFA required + remember device is 12 hours'.html_safe %>
 
+  <%# label the grouping of items using a fieldset and legend for screen readers,
+      and use UL for checkboxes%>
+  <fieldset class='usa-fieldset-inputs usa-fieldset'>
+    <legend class='usa-sr-only'>Attribute bundle</legend>
+    <%= form.label :attribute_bundle,
+                   label: 'Attribute bundle',
+                   class: 'usa-label' %>
+    <%= form.hint 'Refer to our <a href="https://developers.login.gov/attributes" target="_blank">developer documentation</a> for the possible user attributes available at each IAL level that can be requested by your app.'.html_safe %>
+
+    <%= form.collection_check_boxes(:attribute_bundle,
+                                    ServiceProvider.possible_attributes,
+                                    :first, :last,
+                                    collection_wrapper_tag: :ul,
+                                    collection_wrapper_class: 'usa-input-list',
+                                    item_wrapper_tag: :li,
+                                    item_wrapper_class: 'ial-attr-wrapper') do |b| %>
+      <%= b.check_box class: "usa-checkbox__input #{b.text}" %>
+      <%= b.label class: "usa-checkbox__label #{b.text}" %>
+    <% end %>
+  </fieldset>
+
   <%# The 'ml2' class doesn't appear to exist in the css anymore, so the sample issuers are not indented %>
   <%= form.input :issuer,
                  disabled: form.object.persisted?,
@@ -236,7 +257,7 @@ B7xxt8BVc69rHV15A0qyx77CLSj3tCx2IUXVqRs5mlvA==
 
   <%= form.input :failure_to_proof_url,
                  input_html: { class: 'usa-input' },
-                 label: 'Failure to Proof URL — <i>IAL2 Only</i>'.html_safe,
+                 label: 'Failure to Proof URL'.html_safe,
                  hint: 'The URL provided to users who are unable to complete identity proofing and returning to your application.' %>
   <%= form.input :push_notification_url,
                  input_html: { class: 'usa-input' },
@@ -280,26 +301,6 @@ B7xxt8BVc69rHV15A0qyx77CLSj3tCx2IUXVqRs5mlvA==
                     id: 'add-redirect-uri-field',
                     class: 'usa-button margin-bottom-4' %>
   <%# END redirect_uris %>
-
-  <%# label the grouping of items using a fieldset and legend for screen readers,
-      and use UL for checkboxes%>
-  <fieldset class='usa-fieldset-inputs usa-fieldset'>
-    <legend class='usa-sr-only'>Attribute bundle</legend>
-    <%= form.label :attribute_bundle,
-                   label: 'Attribute bundle',
-                   class: 'usa-label' %>
-    <%= form.hint 'Refer to our <a href="https://developers.login.gov/attributes" target="_blank">developer documentation</a> for the possible user attributes available at each IAL level that can be requested by your app.'.html_safe %>
-
-    <%= form.collection_check_boxes(:attribute_bundle,
-                                    ServiceProvider.possible_attributes,
-                                    :first, :last,
-                                    collection_wrapper_tag: :ul,
-                                    collection_wrapper_class: 'usa-input-list',
-                                    item_wrapper_tag: :li) do |b| %>
-      <%= b.check_box class: 'usa-checkbox__input' %>
-      <%= b.label class: 'usa-checkbox__label' %>
-    <% end %>
-  </fieldset>
 
   <legend class='usa-sr-only'>Active</legend>
   <%= form.label :admin,

--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -147,7 +147,7 @@
                    hint: 'The name of the <a href="https://github.com/18F/identity-idp/tree/main/app/assets/images/sp-logos" target="_blank">logo image file</a> in the IdP. The login.gov team can add this image for you.'.html_safe %>
   <% end %>
 
-  <fieldset class="usa-fieldset">
+  <fieldset class="usa-fieldset" id="certificate-container">
     <div class="usa-label">Certificates</div>
 
     <p>

--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -81,7 +81,7 @@
                                     collection_wrapper_class: 'usa-input-list',
                                     item_wrapper_tag: :li,
                                     item_wrapper_class: 'ial-attr-wrapper') do |b| %>
-      <%= b.check_box class: "usa-checkbox__input}" %>
+      <%= b.check_box class: "usa-checkbox__input" %>
       <%= b.label class: "usa-checkbox__label" %>
     <% end %>
   </fieldset>

--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -215,28 +215,28 @@ B7xxt8BVc69rHV15A0qyx77CLSj3tCx2IUXVqRs5mlvA==
   <div class='saml-fields'>
     <%= form.input :acs_url,
                    input_html: { class: 'usa-input' },
-                   label: 'Assertion Consumer Service URL — <i>SAML only</i>'.html_safe,
+                   label: 'Assertion Consumer Service URL'.html_safe,
                    hint: "Your application's endpoint which receives authentication assertions, for example: <code>https://app.agency.gov/auth/saml/sso</code>".html_safe %>
 
     <%= form.input :assertion_consumer_logout_service_url,
                    input_html: { class: 'usa-input' },
-                   label: 'Assertion Consumer Logout Service URL — <i>SAML only</i>'.html_safe,
+                   label: 'Assertion Consumer Logout Service URL'.html_safe,
                    hint: 'The endpoint which receives logout requests and responses, for example: <code>https://app.agency.gov/auth/saml/logout</code>'.html_safe %>
 
     <%= form.input :sp_initiated_login_url,
                    input_html: { class: 'usa-input' },
-                   label: 'SP Initiated Login URL — <i>SAML only</i>'.html_safe,
+                   label: 'SP Initiated Login URL'.html_safe,
                    hint: 'The endpoint which initializes authentication with login.gov. This is used to trigger a new authentication request and response at the SP for better usability. For example: <code>https://app.agency.gov/users/auth/saml/login</code>'.html_safe %>
 
     <%= form.input :block_encryption,
                    input_html: { class: 'usa-select' },
-                   label: 'SAML Assertion Encryption — <i>SAML only</i><br>'.html_safe,
+                   label: 'SAML Assertion Encryption<br>'.html_safe,
                    include_blank: false,
                    hint: 'Whether to encrypt SAML assertions sent to your SP. If set to AES, authentication assertions received at your ACS URL will be encrypted with the public key specified above. If set to none, assertions will be protected only by HTTPS.' %>
 
     <legend class='usa-sr-only'>Signed Response Message Requested</legend>
     <%= form.label :signed_response_message_requested,
-                  label: 'Signed Response Message Requested — <i>SAML only</i>'.html_safe,
+                  label: 'Signed Response Message Requested'.html_safe,
                   class: 'usa-label',
                   hint: 'Change this to "Yes" if you want the entire authentication response signed, as opposed to just the attribute statement.' %>
     <%= form.collection_radio_buttons(:signed_response_message_requested,


### PR DESCRIPTION
Currently, all options are displayed on the application form regardless of what protocol or IAL is selected.

====

Created the mechanisms to dynamically show and hide various inputs that are dependent on the protocol and IAL that the user selected. Also cleared the value of said fields when they are hidden, to prevent unnecessary values being sent when the form is submitted. There is also a bit of modernization of the code and cleanup.

====

**Test steps:**

1. Create a new app
2. Verify that only **OIDC** fields are shown on the form by default
3. Select **SAML** and verify only those are shown
4. **IAL1** is selected by default, ensure only those options are visible
5. Switch to **IAL2** and confirm only those options are visible

