### PR TITLE
Correcting yaml blob conditional attributes and ial number as an integer

### DIFF
--- a/app/helpers/service_provider_helper.rb
+++ b/app/helpers/service_provider_helper.rb
@@ -138,7 +138,7 @@ module ServiceProviderHelper
       'certs' => '<REPLACE_ME>',
       'return_to_sp_url' => sp_hash['return_to_sp_url'],
       'redirect_uris' => sp_hash['redirect_uris'],
-      'ial' => sp_hash['ial'].to_i,
+      'ial' => sp_hash['ial'],
       'attribute_bundle' => sp_hash['attribute_bundle'],
       'protocol' => sp_hash['protocol'],
       'restrict_to_deploy_env' => 'prod',

--- a/app/helpers/service_provider_helper.rb
+++ b/app/helpers/service_provider_helper.rb
@@ -113,6 +113,7 @@ module ServiceProviderHelper
     hash_from_clean_json = JSON.parse(clean_sp_json)
     config_hash = formatted_config_hash(hash_from_clean_json)
     config_hash['protocol'] = service_provider.identity_protocol
+    config_hash['ial'] = service_provider.ial.to_i
     map_config_attributes(config_hash, service_provider.id, service_provider.agency)
   end
 
@@ -137,7 +138,7 @@ module ServiceProviderHelper
       'certs' => '<REPLACE_ME>',
       'return_to_sp_url' => sp_hash['return_to_sp_url'],
       'redirect_uris' => sp_hash['redirect_uris'],
-      'ial' => sp_hash['ial'],
+      'ial' => sp_hash['ial'].to_i,
       'attribute_bundle' => sp_hash['attribute_bundle'],
       'protocol' => sp_hash['protocol'],
       'restrict_to_deploy_env' => 'prod',
@@ -150,27 +151,27 @@ module ServiceProviderHelper
     }
     hash_with_ial_attr = add_IAL_attribute(base_hash, sp_hash['failure_to_proof_url'])
     if base_hash['protocol'] == 'saml'
-      add_saml_attributes(hash_with_ial_attr)
+      add_saml_attributes(hash_with_ial_attr, sp_hash)
     else
       add_oidc_atttributes(hash_with_ial_attr)
     end
   end
 
-  def add_saml_attributes(configs_hash)
+  def add_saml_attributes(configs_hash, sp_hash)
     saml_attrs = {
-      'acs_url' => configs_hash['acs_url'],
+      'acs_url' => sp_hash['acs_url'],
       # rubocop:disable Layout/LineLength
-      'assertion_consumer_logout_service_url' => configs_hash['assertion_consumer_logout_service_url'],
+      'assertion_consumer_logout_service_url' => sp_hash['assertion_consumer_logout_service_url'],
       # rubocop:enable Layout/LineLength
-      'block_encryption' => configs_hash['block_encryption'],
-      'sp_initiated_login_url' => configs_hash['sp_initiated_login_url'],
+      'block_encryption' => sp_hash['block_encryption'],
+      'sp_initiated_login_url' => sp_hash['sp_initiated_login_url'],
       'protocol' => 'saml',
     }
     configs_hash.merge!(saml_attrs)
   end
 
   def add_IAL_attribute(config_hash, failure_to_proof_url)
-    return config_hash if config_hash['ial'] != "'2'"
+    return config_hash if config_hash['ial'] != 2
     config_hash.merge({'failure_to_proof_url' => failure_to_proof_url})
   end
 

--- a/spec/helpers/service_provider_helper_spec.rb
+++ b/spec/helpers/service_provider_helper_spec.rb
@@ -146,6 +146,9 @@ describe ServiceProviderHelper do
         expect(config_hash(oidc_jwt_sp_2)).to include(attribute_name)
       end
     end
+    it 'returns the ial config as an integer instead of a string' do 
+      expect(config_hash(saml_sp_ial_2)['ial'].class).to eq(Integer)
+    end
     it 'returns a hash with failure_to_proof_url if ial 2 - saml' do
       sp_config_saml_attributes.push('failure_to_proof_url')
       sp_config_saml_attributes.each do |attribute_name|

--- a/spec/helpers/service_provider_helper_spec.rb
+++ b/spec/helpers/service_provider_helper_spec.rb
@@ -147,7 +147,7 @@ describe ServiceProviderHelper do
       end
     end
     it 'returns the ial config as an integer instead of a string' do 
-      expect(config_hash(saml_sp_ial_2)['ial'].class).to eq(Integer)
+      expect(config_hash(saml_sp_ial_2)['ial']).to be_an(Integer)
     end
     it 'returns a hash with failure_to_proof_url if ial 2 - saml' do
       sp_config_saml_attributes.push('failure_to_proof_url')


### PR DESCRIPTION
This is correcting some mistakes not covered in #474 . 

- IAL should now be set to a integer
- Conditional attributes for SAML v OIDC should now be populated with the correct data 