### PR TITLE
Remove app_id assignment in yaml blob

### DIFF
--- a/app/helpers/service_provider_helper.rb
+++ b/app/helpers/service_provider_helper.rb
@@ -141,7 +141,7 @@ module ServiceProviderHelper
       'ial' => sp_hash['ial'],
       'attribute_bundle' => sp_hash['attribute_bundle'],
       'protocol' => sp_hash['protocol'],
-      'restrict_to_deploy_env' => 'prod',
+      'restrict_to_deploy_env' => "'prod'",
       'help_text' => sp_hash['help_text'],
       'app_id' => '<REPLACE_WITH_COMMS>',
       'launch_date' => '<REPLACE_ME>',

--- a/app/helpers/service_provider_helper.rb
+++ b/app/helpers/service_provider_helper.rb
@@ -143,7 +143,7 @@ module ServiceProviderHelper
       'protocol' => sp_hash['protocol'],
       'restrict_to_deploy_env' => 'prod',
       'help_text' => sp_hash['help_text'],
-      'app_id' => sp_id,
+      'app_id' => '<REPLACE_WITH_COMMS>',
       'launch_date' => '<REPLACE_ME>',
       'iaa' => '<REPLACE_ME>',
       'iaa_start_date' => '<REPLACE_ME>',


### PR DESCRIPTION
Simply removing the app_id assignment and having the `restrict_to_deploy_env` variable display with quotes in the yaml blob.  There will be more changes with a serializer coming up but due to the glacier development pace on the partnerships team I am not sure when I'll get to it.  I think that this will cause errors if I don't fix it now and the rest is more cosmetic rather than functional.