### PR TITLE
Update CircleCI ruby image (LG-5120)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # Specify the Ruby version you desire here
-      - image: cimg/ruby:2.7.3-node-browsers
+      - image: cimg/ruby:2.7.3
         environment:
           RAILS_ENV: test
           CC_TEST_REPORTER_ID: 39be7be4c9a09e955bd481daa7196fe4dccd67f3ee53e24e91535169eea78123

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # Specify the Ruby version you desire here
-      - image: cimg/ruby:2.7
+      - image: cimg/ruby:2.7-node-browsers
         environment:
           RAILS_ENV: test
           CC_TEST_REPORTER_ID: 39be7be4c9a09e955bd481daa7196fe4dccd67f3ee53e24e91535169eea78123

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
 
       - checkout
 
-      - restore-cache:
+      - restore_cache:
           key: identity-dashboard-{{ checksum "Gemfile.lock" }}
 
       - run:
@@ -46,7 +46,7 @@ jobs:
             chmod +x ./cc-test-reporter
 
       # Store bundle cache
-      - save-cache:
+      - save_cache:
           key: identity-dashboard-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # Specify the Ruby version you desire here
-      - image: cimg/ruby:2.7-node-browsers
+      - image: cimg/ruby:2.7.3-node-browsers
         environment:
           RAILS_ENV: test
           CC_TEST_REPORTER_ID: 39be7be4c9a09e955bd481daa7196fe4dccd67f3ee53e24e91535169eea78123

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # Specify the Ruby version you desire here
-      - image: cimg/ruby:2.7-node-browsers-legacy
+      - image: cimg/ruby:2.7
         environment:
           RAILS_ENV: test
           CC_TEST_REPORTER_ID: 39be7be4c9a09e955bd481daa7196fe4dccd67f3ee53e24e91535169eea78123

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # Specify the Ruby version you desire here
-      - image: circleci/ruby:2.7-node-browsers-legacy
+      - image: cimg/ruby:2.7-node-browsers-legacy
         environment:
           RAILS_ENV: test
           CC_TEST_REPORTER_ID: 39be7be4c9a09e955bd481daa7196fe4dccd67f3ee53e24e91535169eea78123

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 #
 # Check https://circleci.com/docs/2.0/language-ruby/ for more details
 #
-version: 2
+version: 2.1
 orbs:
   browser-tools: circleci/browser-tools@1.1
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,13 @@
 # Check https://circleci.com/docs/2.0/language-ruby/ for more details
 #
 version: 2
+orbs:
+  browser-tools: circleci/browser-tools@1.1
 jobs:
   build:
     docker:
       # Specify the Ruby version you desire here
-      - image: cimg/ruby:2.7.3
+      - image: cimg/ruby:2.7.3-browsers
         environment:
           RAILS_ENV: test
           CC_TEST_REPORTER_ID: 39be7be4c9a09e955bd481daa7196fe4dccd67f3ee53e24e91535169eea78123
@@ -24,6 +26,8 @@ jobs:
     working_directory: ~/identity-dashboard
 
     steps:
+      - browser-tools/install-browser-tools
+
       - checkout
 
       - restore-cache:


### PR DESCRIPTION
An email from CircleCI:
> As of Dec 31, 2021, legacy images will no longer be supported on CircleCI
