### PR TITLE
Return to app url is a conditionally required field

### DIFF
--- a/app/javascript/app/service-provider-form.js
+++ b/app/javascript/app/service-provider-form.js
@@ -15,6 +15,7 @@ $(function () {
   const pemInput = $('.js-pem-input');
   const redirectURI = $('#add-redirect-uri-field');
   const failureToProofURL = $('.service_provider_failure_to_proof_url');
+  const returnToSpUrl = document.querySelector('#service_provider_return_to_sp_url');
 
   const ial1Attributes = ['email', 'x509_subject', 'x509_presented', 'verified_at'];
 
@@ -51,9 +52,11 @@ $(function () {
       case 'openid_connect_private_key_jwt':
       case 'openid_connect_pkce':
         toggleOIDCOptions();
+        returnToSpUrl.removeAttribute('required');
         break;
       case 'saml':
         toggleSAMLOptions();
+        returnToSpUrl.setAttribute('required', 'required');
         break;
       default:
         samlFields.show();

--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -263,13 +263,14 @@ B7xxt8BVc69rHV15A0qyx77CLSj3tCx2IUXVqRs5mlvA==
     <% end %>  
   </div>
 
-  <%= form.input :return_to_sp_url,
-                 input_html: { class: 'usa-input' },
-                 label_html: { class: 'usa-input-required'},
-                 required: true,
-                 label: 'Return to App URL',
-                 hint: "The application's URL which login.gov provides to users when they wish to go directly to the app's site or cancel out of authentication. For example: <code>https://app.agency.gov</code>".html_safe %>
-
+  <div class='saml-fields'>
+    <%= form.input :return_to_sp_url,
+                  input_html: { class: 'usa-input' },
+                  label_html: { class: 'usa-input-required'},
+                  label: 'Return to App URL',
+                  required: true,
+                  hint: "The application's URL which login.gov provides to users when they wish to go directly to the app's site or cancel out of authentication. For example: <code>https://app.agency.gov</code>".html_safe %>
+  </div>
   <%= form.input :failure_to_proof_url,
                  input_html: { class: 'usa-input' },
                  label: 'Failure to Proof URL'.html_safe,

--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -265,6 +265,8 @@ B7xxt8BVc69rHV15A0qyx77CLSj3tCx2IUXVqRs5mlvA==
 
   <%= form.input :return_to_sp_url,
                  input_html: { class: 'usa-input' },
+                 label_html: { class: 'usa-input-required'},
+                 required: true,
                  label: 'Return to App URL',
                  hint: "The application's URL which login.gov provides to users when they wish to go directly to the app's site or cancel out of authentication. For example: <code>https://app.agency.gov</code>".html_safe %>
 

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -14,17 +14,22 @@ en:
         agency: Agency
         assertion_consumer_logout_service_url: Assertion Consumer Logout Service URL
         attribute_bundle: Attribute bundle
-        block_encryption: Block Encryption
+        block_encryption: SAML Assertion Encryption
         description: Description
         friendly_name: Friendly name
         ial: Identity Assurance Level (IAL1 or IAL2)
         issuer: Issuer
         logo: Logo
-        redirect_uris: Redirect URIs
-        return_to_sp_url: Return to SP URL
+        redirect_uris_oidc: Redirect URIs
+        redirect_uris_saml: Additional Redirect URIs
+        redirect_uris_oidc_label: One or more URIs that login.gov will redirect to after authentication.
+        return_to_sp_url: Return to App URL
         sp_initiated_login_url: SP Initiated Login URL
         identity_protocol: Identity Protocol
         team: Team
+        failure_to_proof_url: Failure to Proof URL
+        push_notification_url: Push notification URL
+        signed_response_message_requested: Signed Response Message Requested
       user:
         admin: Admin?
         email: Email

--- a/spec/factories/service_providers.rb
+++ b/spec/factories/service_providers.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :service_provider do
     attribute_bundle { %w[email] }
     sequence(:friendly_name) { |n| "test-service_provider-#{n}" }
-    sequence(:return_to_sp_url) { |n| "https://test-url-#{n}" }
     sequence(:issuer) { |n| "urn:gov:gsa:SAML:2.0.profiles:sp:sso:DEPT:APP-#{n}" }
     sequence(:description) { |n| "test service_provider description #{n}" }
     association :user, factory: :user
@@ -19,6 +18,7 @@ FactoryBot.define do
       assertion_consumer_logout_service_url {'https://fake.gov/test/saml/logout'}
       sp_initiated_login_url {'https://fake.gov/test/saml/sp_login'}
       signed_response_message_requested {1}
+      sequence(:return_to_sp_url) { |n| "https://test-url-#{n}" }
     end
 
     trait :with_oidc_jwt do

--- a/spec/factories/service_providers.rb
+++ b/spec/factories/service_providers.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :service_provider do
     attribute_bundle { %w[email] }
     sequence(:friendly_name) { |n| "test-service_provider-#{n}" }
+    sequence(:return_to_sp_url) { |n| "https://test-url-#{n}" }
     sequence(:issuer) { |n| "urn:gov:gsa:SAML:2.0.profiles:sp:sso:DEPT:APP-#{n}" }
     sequence(:description) { |n| "test service_provider description #{n}" }
     association :user, factory: :user

--- a/spec/features/service_providers_spec.rb
+++ b/spec/features/service_providers_spec.rb
@@ -440,6 +440,7 @@ feature 'Service Providers CRUD' do
     visit service_provider_path(app)
 
     expect(page).to have_content(app.friendly_name)
+    expect(page).to have_content(app.return_to_sp_url)
     expect(page).to have_content(team)
     expect(page).to_not have_content('All service providers')
   end

--- a/spec/features/service_providers_spec.rb
+++ b/spec/features/service_providers_spec.rb
@@ -440,7 +440,6 @@ feature 'Service Providers CRUD' do
     visit service_provider_path(app)
 
     expect(page).to have_content(app.friendly_name)
-    expect(page).to have_content(app.return_to_sp_url)
     expect(page).to have_content(team)
     expect(page).to_not have_content('All service providers')
   end

--- a/spec/features/service_providers_spec.rb
+++ b/spec/features/service_providers_spec.rb
@@ -163,7 +163,7 @@ feature 'Service Providers CRUD' do
       choose('service_provider_identity_protocol_saml', allow_label_click: true)
 
       saml_attributes =
-        %w[acs_url assertion_consumer_logout_service_url sp_initiated_login_url block_encryption return_to_sp_url signed_response_message_requested]
+        %w[acs_url assertion_consumer_logout_service_url sp_initiated_login_url return_to_sp_url block_encryption signed_response_message_requested]
       saml_attributes.each do |atr|
         expect(page).to have_content(t("simple_form.labels.service_provider.#{atr}"))
       end
@@ -181,7 +181,7 @@ feature 'Service Providers CRUD' do
       choose('service_provider_identity_protocol_openid_connect_private_key_jwt', allow_label_click: true)
 
       saml_attributes =
-        %w[acs_url assertion_consumer_logout_service_url sp_initiated_login_url block_encryption return_to_sp_url signed_response_message_requested]
+        %w[acs_url assertion_consumer_logout_service_url sp_initiated_login_url return_to_sp_url block_encryption signed_response_message_requested]
       saml_attributes.each do |atr|
         expect(page).to_not have_content(t("simple_form.labels.service_provider.#{atr}"))
       end

--- a/spec/features/service_providers_spec.rb
+++ b/spec/features/service_providers_spec.rb
@@ -154,72 +154,41 @@ feature 'Service Providers CRUD' do
       expect(page).not_to have_css('input#service_provider_email_nameid_format_allowed')
     end
 
-    # Poltergeist is attempting to click at coordinates [-16333, 22.5] when
-    # choosing the protocol in the following four scenarios.
     # rubocop:disable Layout/LineLength
-    xscenario 'saml fields are shown when saml is selected', :js do
+    scenario 'saml fields are shown when saml is selected', :js do
       user = create(:user)
       login_as(user)
 
       visit new_service_provider_path
-      choose 'Saml'
+      choose('service_provider_identity_protocol_saml', allow_label_click: true)
 
       saml_attributes =
-        %w[acs_url assertion_consumer_logout_service_url sp_initiated_login_url return_to_sp_url failure_to_proof_url push_notification_url]
+        %w[acs_url assertion_consumer_logout_service_url sp_initiated_login_url block_encryption return_to_sp_url signed_response_message_requested]
       saml_attributes.each do |atr|
         expect(page).to have_content(t("simple_form.labels.service_provider.#{atr}"))
       end
 
-      expect(page).to_not have_content(t('simple_form.labels.service_provider.redirect_uris'))
+      # Redirect URIs (for oidc) is found in Additional Redirect URIs (saml) so instead we assert that
+      # the oidc hint label is not found since the content there is dissimilar enough
+      expect(page).to_not have_content(t('simple_form.labels.service_provider.redirect_uris_oidc_label'))
     end
 
-    xscenario 'oidc fields are shown when oidc is selected', :js do
+    scenario 'oidc fields are shown when oidc is selected', :js do
       user = create(:user)
       login_as(user)
 
       visit new_service_provider_path
-
-      choose 'Openid connect'
+      choose('service_provider_identity_protocol_openid_connect_private_key_jwt', allow_label_click: true)
 
       saml_attributes =
-        %w[acs_url assertion_consumer_logout_service_url sp_initiated_login_url return_to_sp_url failure_to_proof_url push_notification_url]
+        %w[acs_url assertion_consumer_logout_service_url sp_initiated_login_url block_encryption return_to_sp_url signed_response_message_requested]
       saml_attributes.each do |atr|
         expect(page).to_not have_content(t("simple_form.labels.service_provider.#{atr}"))
       end
 
-      expect(page).to have_content(t('simple_form.labels.service_provider.redirect_uris'))
+      expect(page).to have_content(t('simple_form.labels.service_provider.redirect_uris_oidc_label'))
     end
     # rubocop:enable Layout/LineLength
-
-    xscenario 'issuer is updated when department or app is updated', :js do
-      user = create(:user)
-      login_as(user)
-
-      visit new_service_provider_path
-
-      choose 'Openid connect'
-      fill_in 'Issuer department', with: 'ABC'
-      fill_in 'Issuer app', with: 'my-cool-app'
-
-      expect(find_field('service_provider_issuer', disabled: true).value).to eq(
-        'urn:gov:gsa:openidconnect.profiles:sp:sso:ABC:my-cool-app',
-      )
-    end
-
-    xscenario 'issuer protocol is changed when oidc or saml is selected', :js do
-      user = create(:user)
-      login_as(user)
-
-      visit new_service_provider_path
-
-      choose 'Saml'
-      fill_in 'Issuer department', with: 'ABC'
-      fill_in 'Issuer app', with: 'my-cool-app'
-
-      expect(find_field('service_provider_issuer', disabled: true).value).to eq(
-        'urn:gov:gsa:SAML:2.0.profiles:sp:sso:ABC:my-cool-app',
-      )
-    end
   end
 
   context 'admin user' do


### PR DESCRIPTION
### Work Ticket
https://cm-jira.usa.gov/browse/LG-5083

### Changes

- Add front end changes to make return_to_sp_url a required field for all SAML integrations
- Hide return_to_sp_url for OIDC integrations and make the field not required so that SPs can submit the form
- Update unit tests
- Update field content

### PR Checklist:

1. Have you tagged the appropriate dev(s) for review?
2. Have you moved any Jira/Smartsheet tickets to Code Review?
