### PR TITLE
Add test for toggling protocols when editing service providers

### DIFF
--- a/spec/factories/service_providers.rb
+++ b/spec/factories/service_providers.rb
@@ -14,6 +14,10 @@ FactoryBot.define do
 
     trait :saml do
       identity_protocol { :saml }
+      acs_url {"https://fake.gov/test/saml/acs"}
+      assertion_consumer_logout_service_url {"https://fake.gov/test/saml/logout"}
+      sp_initiated_login_url {"https://fake.gov/test/saml/sp_login"}
+      signed_response_message_requested {1}
     end
 
     trait :with_oidc_jwt do

--- a/spec/factories/service_providers.rb
+++ b/spec/factories/service_providers.rb
@@ -14,9 +14,9 @@ FactoryBot.define do
 
     trait :saml do
       identity_protocol { :saml }
-      acs_url {"https://fake.gov/test/saml/acs"}
-      assertion_consumer_logout_service_url {"https://fake.gov/test/saml/logout"}
-      sp_initiated_login_url {"https://fake.gov/test/saml/sp_login"}
+      acs_url {'https://fake.gov/test/saml/acs'}
+      assertion_consumer_logout_service_url {'https://fake.gov/test/saml/logout'}
+      sp_initiated_login_url {'https://fake.gov/test/saml/sp_login'}
       signed_response_message_requested {1}
     end
 

--- a/spec/features/service_providers_spec.rb
+++ b/spec/features/service_providers_spec.rb
@@ -107,6 +107,32 @@ feature 'Service Providers CRUD' do
       )
     end
 
+    scenario 'switching protocols when editing a saml sp should persist saml info', :js do
+      user = create(:user, :with_teams)
+      service_provider = create(:service_provider, :saml, :with_users_team, user: user)
+
+      login_as(user)
+
+      visit edit_service_provider_path(service_provider)
+
+      choose('service_provider_identity_protocol_openid_connect_private_key_jwt', allow_label_click: true)
+      choose('service_provider_identity_protocol_saml', allow_label_click: true)
+
+      expect(find_field('Assertion Consumer Service URL', disabled: false).value).to eq(
+        'https://fake.gov/test/saml/acs',
+      )
+      expect(find_field('Assertion Consumer Logout Service URL', disabled: false).value).to eq(
+        'https://fake.gov/test/saml/logout',
+      )
+
+      expect(find_field('SP Initiated Login URL', disabled: false).value).to eq(
+        'https://fake.gov/test/saml/sp_login',
+      )
+      expect(find_field('SAML Assertion Encryption', disabled: false).value).to eq(
+        'aes256-cbc',
+      )
+    end
+
     scenario 'can update saml service provider with multiple redirect uris', :js do
       user = create(:user, :with_teams)
       service_provider = create(:service_provider, :saml, :with_users_team, user: user)

--- a/spec/features/service_providers_spec.rb
+++ b/spec/features/service_providers_spec.rb
@@ -92,10 +92,19 @@ feature 'Service Providers CRUD' do
 
       visit edit_service_provider_path(service_provider)
 
-      expect(find_field('Assertion Consumer Service URL', disabled: false).value).to eq("https://fake.gov/test/saml/acs")
-      expect(find_field('Assertion Consumer Logout Service URL', disabled: false).value).to eq("https://fake.gov/test/saml/logout")
-      expect(find_field('SP Initiated Login URL', disabled: false).value).to eq("https://fake.gov/test/saml/sp_login")
-      expect(find_field('SAML Assertion Encryption', disabled: false).value).to eq("aes256-cbc")
+      expect(find_field('Assertion Consumer Service URL', disabled: false).value).to eq(
+        'https://fake.gov/test/saml/acs',
+      )
+      expect(find_field('Assertion Consumer Logout Service URL', disabled: false).value).to eq(
+        'https://fake.gov/test/saml/logout',
+      )
+
+      expect(find_field('SP Initiated Login URL', disabled: false).value).to eq(
+        'https://fake.gov/test/saml/sp_login',
+      )
+      expect(find_field('SAML Assertion Encryption', disabled: false).value).to eq(
+        'aes256-cbc',
+      )
     end
 
     scenario 'can update saml service provider with multiple redirect uris', :js do

--- a/spec/features/service_providers_spec.rb
+++ b/spec/features/service_providers_spec.rb
@@ -88,9 +88,6 @@ feature 'Service Providers CRUD' do
       user = create(:user, :with_teams)
       service_provider = create(:service_provider, :saml, :with_users_team, user: user)
 
-      saml_only_assertion_consumer = "Your application's endpoint which receives authentication"
-      saml_only_assertion_logout = 'The endpoint which receives logout requests and responses'
-
       login_as(user)
 
       visit edit_service_provider_path(service_provider)

--- a/spec/features/service_providers_spec.rb
+++ b/spec/features/service_providers_spec.rb
@@ -95,8 +95,10 @@ feature 'Service Providers CRUD' do
 
       visit edit_service_provider_path(service_provider)
 
-      expect(page).to have_content(saml_only_assertion_consumer)
-      expect(page).to have_content(saml_only_assertion_logout)
+      expect(find_field('Assertion Consumer Service URL', disabled: false).value).to eq("https://fake.gov/test/saml/acs")
+      expect(find_field('Assertion Consumer Logout Service URL', disabled: false).value).to eq("https://fake.gov/test/saml/logout")
+      expect(find_field('SP Initiated Login URL', disabled: false).value).to eq("https://fake.gov/test/saml/sp_login")
+      expect(find_field('SAML Assertion Encryption', disabled: false).value).to eq("aes256-cbc")
     end
 
     scenario 'can update saml service provider with multiple redirect uris', :js do

--- a/spec/features/service_providers_spec.rb
+++ b/spec/features/service_providers_spec.rb
@@ -115,7 +115,10 @@ feature 'Service Providers CRUD' do
 
       visit edit_service_provider_path(service_provider)
 
-      choose('service_provider_identity_protocol_openid_connect_private_key_jwt', allow_label_click: true)
+      choose(
+        'service_provider_identity_protocol_openid_connect_private_key_jwt', 
+        allow_label_click: true,
+      )
       choose('service_provider_identity_protocol_saml', allow_label_click: true)
 
       expect(find_field('Assertion Consumer Service URL', disabled: false).value).to eq(

--- a/spec/features/service_providers_spec.rb
+++ b/spec/features/service_providers_spec.rb
@@ -84,6 +84,21 @@ feature 'Service Providers CRUD' do
       expect(service_provider.redirect_uris).to eq(['https://bar.com'])
     end
 
+    scenario 'can view all saml fields when editing a saml app', :js do
+      user = create(:user, :with_teams)
+      service_provider = create(:service_provider, :saml, :with_users_team, user: user)
+
+      saml_only_assertion_consumer = "Your application's endpoint which receives authentication"
+      saml_only_assertion_logout = 'The endpoint which receives logout requests and responses'
+
+      login_as(user)
+
+      visit edit_service_provider_path(service_provider)
+
+      expect(page).to have_content(saml_only_assertion_consumer)
+      expect(page).to have_content(saml_only_assertion_logout)
+    end
+
     scenario 'can update saml service provider with multiple redirect uris', :js do
       user = create(:user, :with_teams)
       service_provider = create(:service_provider, :saml, :with_users_team, user: user)


### PR DESCRIPTION
### Work Ticket
Piggy-backing off of https://github.com/18F/identity-dashboard/pull/495

### Changes

-   Add test for toggling protocol on saml service providers does not lose user entered saml data

### PR Checklist:

1. Have you tagged the appropriate dev(s) for review?
2. Have you moved any Jira/Smartsheet tickets to Code Review?
