### PR TITLE
Add PKI service to deploy dashboard

### DIFF
--- a/config/status_checks.yml
+++ b/config/status_checks.yml
@@ -10,6 +10,9 @@ deploys:
   - app: 'identity-saml-sinatra'
     env: 'prod'
     host: 'https://prod-identity-saml-sinatra.app.cloud.gov/'
+  - app: 'identity-pki'
+    env: 'prod'
+    host: 'https://checking-deploy.pivcac.prod.login.gov'
 
   # Staging
   - app: 'identity-idp'
@@ -21,6 +24,9 @@ deploys:
   - app: 'identity-saml-sinatra'
     env: 'staging'
     host: 'https://staging-identity-saml-sinatra.app.cloud.gov/'
+  - app: 'identity-pki'
+    env: 'staging'
+    host: 'https://checking-deploy.pivcac.staging.login.gov'
 
   # Data Migration
   - app: 'identity-idp'
@@ -32,6 +38,9 @@ deploys:
   - app: 'identity-saml-sinatra'
     env: 'dm'
     host: 'https://dm-identity-saml-sinatra.app.cloud.gov/'
+  - app: 'identity-pki'
+    env: 'dm'
+    host: 'https://checking-deploy.pivcac.dm.login.gov'
 
   # Agency integration
   - app: 'identity-idp'
@@ -46,6 +55,9 @@ deploys:
   - app: 'identity-saml-sinatra'
     env: 'int'
     host: 'https://int-identity-saml-sinatra.app.cloud.gov/'
+  - app: 'identity-pki'
+    env: 'int'
+    host: 'https://checking-deploy.pivcac.int.identitysandbox.gov'
 
   # Development
   - app: 'identity-idp'
@@ -60,3 +72,6 @@ deploys:
   - app: 'identity-saml-sinatra'
     env: 'dev'
     host: 'https://dev-identity-saml-sinatra.app.cloud.gov/'
+  - app: 'identity-pki'
+    env: 'dev'
+    host: 'https://checking-deploy.pivcac.dev.identitysandbox.gov'

--- a/spec/support/deploy_status_checker_helper.rb
+++ b/spec/support/deploy_status_checker_helper.rb
@@ -8,6 +8,7 @@ module DeployStatusCheckerHelper
     }.as_json
   end
 
+  # rubocop:disable Layout/LineLength
   def stub_deploy_status
     stub_request(:get, %r{https://secure\.login\.gov/api/deploy\.json}).
       to_return(body: stub_status_json.to_json)
@@ -16,6 +17,8 @@ module DeployStatusCheckerHelper
     stub_request(:get, %r{https://.*\.int\.identitysandbox\.gov/api/deploy\.json}).
       to_return(body: stub_status_json.to_json)
     stub_request(:get, %r{https://(int|staging|prod|dm)-.*\.cloud\.gov/api/deploy\.json}).
+      to_return(body: stub_status_json.to_json)
+    stub_request(:get,%r{https://checking-deploy.pivcac.(dev|int|staging|prod|dm).(login|identitysandbox).gov/api/deploy\.json}).
       to_return(body: stub_status_json.to_json)
     stub_request(:get, %r{https://.*\.dev\.identitysandbox\.gov/api/deploy\.json}).
       to_return(status: 404)
@@ -28,4 +31,5 @@ module DeployStatusCheckerHelper
     stub_request(:get, %r{https://dm-.*\.cloud\.gov/api/deploy\.json}).
       to_timeout
   end
+  # rubocop:enable Layout/LineLength
 end


### PR DESCRIPTION
I'm appdev oncall (aka deployer) this week, and I wanted a quick way to see if there were pending changes to the PKI app I should deploy, so I figured this was worth adding.

**Note**: Will likely need a proxy change in devops to allow these requests to work

<img width="652" alt="Screen Shot 2022-01-18 at 9 53 00 AM" src="https://user-images.githubusercontent.com/458784/149991946-1a11bfea-845d-4872-9d12-825446f0196a.png">

