### PR TITLE
[LG-5703] Do not upload empty/null certs to Dashboard config

### DIFF
--- a/app/controllers/service_providers_controller.rb
+++ b/app/controllers/service_providers_controller.rb
@@ -155,7 +155,8 @@ class ServiceProvidersController < AuthenticatedController
     return if params.dig(:service_provider, :cert).blank?
 
     service_provider.certs ||= []
-    service_provider.certs << params[:service_provider].delete(:cert).read
+    crt = params[:service_provider].delete(:cert).read
+    service_provider.certs << crt unless crt.blank?
   end
 
   def remove_certificates

--- a/spec/controllers/service_providers_controller_spec.rb
+++ b/spec/controllers/service_providers_controller_spec.rb
@@ -145,5 +145,15 @@ describe ServiceProvidersController do
         put :update, params: { id: sp.id, service_provider: { issuer: sp.issuer, cert: file } }
       end.to_not(change { sp.reload.certs&.size })
     end
+
+    it 'does not update cert array when cert data is null/empty' do
+      empty_file = Rack::Test::UploadedFile.new(
+        StringIO.new(''),
+        original_filename: 'my-cert.crt',
+      )
+
+      put :update, params: { id: sp.id, service_provider: { issuer: sp.issuer, cert: empty_file } }
+      expect(sp.reload.certs&.size).to equal(0)
+    end
   end
 end


### PR DESCRIPTION
### Work Ticket
https://cm-jira.usa.gov/browse/LG-5703

### Changes

-   For empty/null certs, do not add them to the SP cert array or they WILL save as null certs to the SP

### PR Checklist:

1. Have you tagged the appropriate dev(s) for review?
2. Have you moved any Jira/Smartsheet tickets to Code Review?
