### PR TITLE
Start converting jQuery code to plain old fashioned javascript

### DIFF
--- a/app/javascript/app/service-provider-form.js
+++ b/app/javascript/app/service-provider-form.js
@@ -57,7 +57,6 @@ function protocolOptionSetup() {
 
   // Functions
   const toggleSAMLOptions = () => {
-
     samlFields.forEach(showElement);
     oidcFields.forEach(hideElement);
   };

--- a/app/javascript/app/service-provider-form.js
+++ b/app/javascript/app/service-provider-form.js
@@ -7,17 +7,17 @@ function ialOptionSetup() {
 
   // Functions
   const toggleIAL1Options = () => {
-    ialAttributesCheckboxes.forEach(checkboxWrapper => {
+    ialAttributesCheckboxes.forEach((checkboxWrapper) => {
       const checkboxInput = checkboxWrapper.querySelector('input');
       if (ial1Attributes.includes(checkboxInput.value)) {
         checkboxWrapper.classList.add('display-none');
-        checkboxInput.checked = false
+        checkboxInput.checked = false;
       }
     });
   };
 
   const toggleIAL2Options = () => {
-    ialAttributesCheckboxes.forEach(checkboxWrapper => {
+    ialAttributesCheckboxes.forEach((checkboxWrapper) => {
       checkboxWrapper.classList.remove('display-none');
     });
   };
@@ -54,13 +54,13 @@ function protocolOptionSetup() {
 
   // Functions
   const toggleSAMLOptions = () => {
-    samlFields.forEach(field => field.classList.remove('display-none'));
-    oidcFields.forEach(field => field.classList.add('display-none'));
+    samlFields.forEach((field) => field.classList.remove('display-none'));
+    oidcFields.forEach((field) => field.classList.add('display-none'));
   };
 
   const toggleOIDCOptions = () => {
-    oidcFields.forEach(field => field.classList.remove('display-none'));
-    samlFields.forEach(field => field.classList.add('display-none'));
+    oidcFields.forEach((field) => field.classList.remove('display-none'));
+    samlFields.forEach((field) => field.classList.add('display-none'));
   };
 
   const toggleFormFields = (protocol) => {
@@ -75,8 +75,8 @@ function protocolOptionSetup() {
         returnToSpUrl.setAttribute('required', 'required');
         break;
       default:
-        samlFields.forEach(field => field.classList.remove('display-none'));
-        oidcFields.forEach(field => field.classList.remove('display-none'));
+        samlFields.forEach((field) => field.classList.remove('display-none'));
+        oidcFields.forEach((field) => field.classList.remove('display-none'));
     }
   };
 
@@ -84,15 +84,14 @@ function protocolOptionSetup() {
   toggleFormFields(activeIdProtocol.value);
 
   // Event triggers
-  idProtocols.forEach(idProtocol => {
+  idProtocols.forEach((idProtocol) => {
     idProtocol.addEventListener("change", (event) => toggleFormFields(event.target.value));
   });
-};
+}
 
 function serviceProviderForm() {
   ialOptionSetup();
   protocolOptionSetup();
-  certificateUploadSetup();
 }
 
 window.addEventListener('DOMContentLoaded', serviceProviderForm);
@@ -108,8 +107,6 @@ $(function () {
   const pemInputMessage = $('.js-pem-input-error-message');
   const pemInput = $('.js-pem-input');
   const redirectURI = $('#add-redirect-uri-field');
-
-  const ial1Attributes = ['email', 'all_emails', 'x509_subject', 'x509_presented', 'verified_at'];
 
   // Functions
 

--- a/app/javascript/app/service-provider-form.js
+++ b/app/javascript/app/service-provider-form.js
@@ -93,6 +93,10 @@ function protocolOptionSetup() {
 }
 
 function serviceProviderForm() {
+  if (!document.querySelector('.service-provider-form')) {
+    return;
+  }
+
   ialOptionSetup();
   protocolOptionSetup();
 }

--- a/app/javascript/app/service-provider-form.js
+++ b/app/javascript/app/service-provider-form.js
@@ -1,6 +1,6 @@
 function ialOptionSetup() {
   // Selectors
-  const ialLevel = document.querySelector('#service_provider_ial');
+  const ialLevel = document.getElementById('service_provider_ial');
   const ialAttributesCheckboxes = document.querySelectorAll('.ial-attr-wrapper');
   const failureToProofURL = document.querySelector('.service_provider_failure_to_proof_url');
   const ial1Attributes = ['email', 'all_emails', 'x509_subject', 'x509_presented', 'verified_at'];
@@ -50,7 +50,7 @@ function protocolOptionSetup() {
   const activeIdProtocol = document.querySelector('input[name="service_provider[identity_protocol]"]:checked');
   const samlFields = document.querySelectorAll('.saml-fields');
   const oidcFields = document.querySelectorAll('.oidc-fields');
-  const returnToSpUrl = document.querySelector('#service_provider_return_to_sp_url');
+  const returnToSpUrl = document.getElementById('service_provider_return_to_sp_url');
 
   // Functions
   const toggleSAMLOptions = () => {

--- a/app/javascript/app/service-provider-form.js
+++ b/app/javascript/app/service-provider-form.js
@@ -1,51 +1,67 @@
-$(function () {
-  if (!$('.service-provider-form').length) {
-    return;
-  }
-
+function ialOptionSetup() {
   // Selectors
-  const idProtocol = $('input[name="service_provider[identity_protocol]"]');
-  const ialLevel = $('#service_provider_ial');
-  const samlFields = $('.saml-fields');
-  const oidcFields = $('.oidc-fields');
-  const ialAttributesCheckboxes = $('.ial-attr-wrapper');
-  const fileContainer = $('#certificate-container');
-  const logoInput = $('.input-file');
-  const pemInputMessage = $('.js-pem-input-error-message');
-  const pemInput = $('.js-pem-input');
-  const redirectURI = $('#add-redirect-uri-field');
-  const failureToProofURL = $('.service_provider_failure_to_proof_url');
-  const returnToSpUrl = document.querySelector('#service_provider_return_to_sp_url');
-
+  const ialLevel = document.querySelector('#service_provider_ial');
+  const ialAttributesCheckboxes = document.querySelectorAll('.ial-attr-wrapper');
+  const failureToProofURL = document.querySelector('.service_provider_failure_to_proof_url');
   const ial1Attributes = ['email', 'all_emails', 'x509_subject', 'x509_presented', 'verified_at'];
 
   // Functions
   const toggleIAL1Options = () => {
-    ialAttributesCheckboxes.each((idx, attr) => {
-      const element = $(attr).find('input');
-
-      if (!ial1Attributes.includes(element.val())) {
-        $(attr).hide();
-        element.prop('checked', false);
+    ialAttributesCheckboxes.forEach(checkboxWrapper => {
+      const checkboxInput = checkboxWrapper.querySelector('input');
+      if (ial1Attributes.includes(checkboxInput.value)) {
+        checkboxWrapper.classList.add('display-none');
+        checkboxInput.checked = false
       }
     });
   };
 
   const toggleIAL2Options = () => {
-    ialAttributesCheckboxes.each((idx, attr) => $(attr).show());
+    ialAttributesCheckboxes.forEach(checkboxWrapper => {
+      checkboxWrapper.classList.remove('display-none');
+    });
   };
 
+  const toggleIALOptions = (ial) => {
+    switch (ial) {
+      case '1':
+        failureToProofURL.classList.add('display-none');
+        toggleIAL1Options();
+        break;
+      case '2':
+        failureToProofURL.classList.remove('display-none');
+        toggleIAL2Options();
+        break;
+      default:
+        failureToProofURL.remove('display-none');
+        toggleIAL2Options();
+    }
+  };
+
+  // Page initialization
+  toggleIALOptions(ialLevel.value);
+
+  // Event trigger
+  ialLevel.addEventListener("change", (event) => toggleIALOptions(event.target.value));
+}
+
+function protocolOptionSetup() {
+  const idProtocols = document.querySelectorAll('input[name="service_provider[identity_protocol]"]');
+  const activeIdProtocol = document.querySelector('input[name="service_provider[identity_protocol]"]:checked');
+  const samlFields = document.querySelectorAll('.saml-fields');
+  const oidcFields = document.querySelectorAll('.oidc-fields');
+  const returnToSpUrl = document.querySelector('#service_provider_return_to_sp_url');
+
+  // Functions
   const toggleSAMLOptions = () => {
-    samlFields.show();
-    oidcFields.hide();
+    samlFields.forEach(field => field.classList.remove('display-none'));
+    oidcFields.forEach(field => field.classList.add('display-none'));
   };
 
   const toggleOIDCOptions = () => {
-    oidcFields.show();
-    samlFields.hide();
+    oidcFields.forEach(field => field.classList.remove('display-none'));
+    samlFields.forEach(field => field.classList.add('display-none'));
   };
-
-  const setPemError = (message) => (pemInputMessage[0].textContent = message); // eslint-disable-line
 
   const toggleFormFields = (protocol) => {
     switch (protocol) {
@@ -59,35 +75,45 @@ $(function () {
         returnToSpUrl.setAttribute('required', 'required');
         break;
       default:
-        samlFields.show();
-        oidcFields.show();
-    }
-  };
-
-  const toggleIALOptions = (ial) => {
-    switch (ial) {
-      case '1':
-        failureToProofURL.hide();
-        toggleIAL1Options();
-        break;
-      case '2':
-        failureToProofURL.show();
-        toggleIAL2Options();
-        break;
-      default:
-        failureToProofURL.show();
-        toggleIAL2Options();
+        samlFields.forEach(field => field.classList.remove('display-none'));
+        oidcFields.forEach(field => field.classList.remove('display-none'));
     }
   };
 
   // Page initialization
-  toggleFormFields(idProtocol.filter(':checked').val());
-  toggleIALOptions(ialLevel.val());
+  toggleFormFields(activeIdProtocol.value);
 
   // Event triggers
-  idProtocol.change((evt) => toggleFormFields(evt.target.value));
+  idProtocols.forEach(idProtocol => {
+    idProtocol.addEventListener("change", (event) => toggleFormFields(event.target.value));
+  });
+};
 
-  ialLevel.change((evt) => toggleIALOptions(evt.target.value));
+function serviceProviderForm() {
+  ialOptionSetup();
+  protocolOptionSetup();
+  certificateUploadSetup();
+}
+
+window.addEventListener('DOMContentLoaded', serviceProviderForm);
+
+$(function () {
+  if (!$('.service-provider-form').length) {
+    return;
+  }
+
+  // Selectors
+  const fileContainer = $('#certificate-container');
+  const logoInput = $('.input-file');
+  const pemInputMessage = $('.js-pem-input-error-message');
+  const pemInput = $('.js-pem-input');
+  const redirectURI = $('#add-redirect-uri-field');
+
+  const ial1Attributes = ['email', 'all_emails', 'x509_subject', 'x509_presented', 'verified_at'];
+
+  // Functions
+
+  const setPemError = (message) => (pemInputMessage[0].textContent = message); // eslint-disable-line
 
   redirectURI.click(() =>
       $('.service_provider_redirect_uris input:last-child')

--- a/app/javascript/app/service-provider-form.js
+++ b/app/javascript/app/service-provider-form.js
@@ -1,5 +1,5 @@
-const toggleElementVisibility = (element, isVisible) =>
-  element.classList.toggle('display-none', !isVisible);
+const showElement = (element) => element.classList.remove('display-none');
+const hideElement = (element) => element.classList.add('display-none');
 
 function ialOptionSetup() {
   // Selectors
@@ -13,7 +13,7 @@ function ialOptionSetup() {
     ialAttributesCheckboxes.forEach((checkboxWrapper) => {
       const checkboxInput = checkboxWrapper.querySelector('input');
       if (ial1Attributes.includes(checkboxInput.value)) {
-        toggleElementVisibility(checkboxWrapper, false);
+        hideElement(checkboxWrapper);
         checkboxInput.checked = false;
       }
     });
@@ -21,22 +21,22 @@ function ialOptionSetup() {
 
   const toggleIAL2Options = () => {
     ialAttributesCheckboxes.forEach((checkboxWrapper) => {
-      toggleElementVisibility(checkboxWrapper, true);
+      showElement(checkboxWrapper);
     });
   };
 
   const toggleIALOptions = (ial) => {
     switch (ial) {
       case '1':
-        toggleElementVisibility(failureToProofURL, false);
+        hideElement(failureToProofURL);
         toggleIAL1Options();
         break;
       case '2':
-        toggleElementVisibility(failureToProofURL, true);
+        showElement(failureToProofURL);
         toggleIAL2Options();
         break;
       default:
-        toggleElementVisibility(failureToProofURL, true);
+        showElement(failureToProofURL);
         toggleIAL2Options();
     }
   };
@@ -57,14 +57,14 @@ function protocolOptionSetup() {
 
   // Functions
   const toggleSAMLOptions = () => {
-    samlFields.forEach((field) => toggleElementVisibility(field, true));
 
-    oidcFields.forEach((field) => toggleElementVisibility(field, false));
+    samlFields.forEach(showElement);
+    oidcFields.forEach(hideElement);
   };
 
   const toggleOIDCOptions = () => {
-    oidcFields.forEach((field) => toggleElementVisibility(field, true));
-    samlFields.forEach((field) => toggleElementVisibility(field, false));
+    oidcFields.forEach(showElement);
+    samlFields.forEach(hideElement);
   };
 
   const toggleFormFields = (protocol) => {
@@ -79,8 +79,8 @@ function protocolOptionSetup() {
         returnToSpUrl.setAttribute('required', 'required');
         break;
       default:
-        samlFields.forEach((field) => toggleElementVisibility(field, true));
-        oidcFields.forEach((field) => toggleElementVisibility(field, true));
+        samlFields.forEach(showElement);
+        oidcFields.forEach(showElement);
     }
   };
 

--- a/app/javascript/app/service-provider-form.js
+++ b/app/javascript/app/service-provider-form.js
@@ -12,7 +12,7 @@ function ialOptionSetup() {
   const toggleIAL1Options = () => {
     ialAttributesCheckboxes.forEach((checkboxWrapper) => {
       const checkboxInput = checkboxWrapper.querySelector('input');
-      if (ial1Attributes.includes(checkboxInput.value)) {
+      if (!ial1Attributes.includes(checkboxInput.value)) {
         hideElement(checkboxWrapper);
         checkboxInput.checked = false;
       }

--- a/app/javascript/app/service-provider-form.js
+++ b/app/javascript/app/service-provider-form.js
@@ -1,3 +1,6 @@
+const toggleElementVisibility = (element, isVisible) =>
+  element.classList.toggle('display-none', !isVisible);
+
 function ialOptionSetup() {
   // Selectors
   const ialLevel = document.getElementById('service_provider_ial');
@@ -10,7 +13,7 @@ function ialOptionSetup() {
     ialAttributesCheckboxes.forEach((checkboxWrapper) => {
       const checkboxInput = checkboxWrapper.querySelector('input');
       if (ial1Attributes.includes(checkboxInput.value)) {
-        checkboxWrapper.classList.add('display-none');
+        toggleElementVisibility(checkboxWrapper, false);
         checkboxInput.checked = false;
       }
     });
@@ -18,22 +21,22 @@ function ialOptionSetup() {
 
   const toggleIAL2Options = () => {
     ialAttributesCheckboxes.forEach((checkboxWrapper) => {
-      checkboxWrapper.classList.remove('display-none');
+      toggleElementVisibility(checkboxWrapper, true);
     });
   };
 
   const toggleIALOptions = (ial) => {
     switch (ial) {
       case '1':
-        failureToProofURL.classList.add('display-none');
+        toggleElementVisibility(failureToProofURL, false);
         toggleIAL1Options();
         break;
       case '2':
-        failureToProofURL.classList.remove('display-none');
+        toggleElementVisibility(failureToProofURL, true);
         toggleIAL2Options();
         break;
       default:
-        failureToProofURL.remove('display-none');
+        toggleElementVisibility(failureToProofURL, true);
         toggleIAL2Options();
     }
   };
@@ -54,13 +57,14 @@ function protocolOptionSetup() {
 
   // Functions
   const toggleSAMLOptions = () => {
-    samlFields.forEach((field) => field.classList.remove('display-none'));
-    oidcFields.forEach((field) => field.classList.add('display-none'));
+    samlFields.forEach((field) => toggleElementVisibility(field, true));
+
+    oidcFields.forEach((field) => toggleElementVisibility(field, false));
   };
 
   const toggleOIDCOptions = () => {
-    oidcFields.forEach((field) => field.classList.remove('display-none'));
-    samlFields.forEach((field) => field.classList.add('display-none'));
+    oidcFields.forEach((field) => toggleElementVisibility(field, true));
+    samlFields.forEach((field) => toggleElementVisibility(field, false));
   };
 
   const toggleFormFields = (protocol) => {
@@ -75,8 +79,8 @@ function protocolOptionSetup() {
         returnToSpUrl.setAttribute('required', 'required');
         break;
       default:
-        samlFields.forEach((field) => field.classList.remove('display-none'));
-        oidcFields.forEach((field) => field.classList.remove('display-none'));
+        samlFields.forEach((field) => toggleElementVisibility(field, true));
+        oidcFields.forEach((field) => toggleElementVisibility(field, true));
     }
   };
 

--- a/spec/features/service_providers_spec.rb
+++ b/spec/features/service_providers_spec.rb
@@ -163,7 +163,7 @@ feature 'Service Providers CRUD' do
       visit edit_service_provider_path(service_provider)
 
       choose(
-        'service_provider_identity_protocol_openid_connect_private_key_jwt', 
+        'service_provider_identity_protocol_openid_connect_private_key_jwt',
         allow_label_click: true,
       )
       choose('service_provider_identity_protocol_saml', allow_label_click: true)
@@ -263,6 +263,42 @@ feature 'Service Providers CRUD' do
       end
 
       expect(page).to have_content(strip_tags(t('service_provider_form.oidc_redirects')))
+    end
+
+    scenario 'IAL1 attributes shown when IAL1 is selected', :js do
+      user = create(:user)
+      login_as(user)
+
+      visit new_service_provider_path
+      select('Authentication only', from: 'Level of Service')
+
+      ial1_attributes = %w[email all_emails verified_at x509_subject x509_presented]
+      ial2_attributes = %w[first_name last_name dob ssn address1 address2 city state zipcode phone]
+
+      ial1_attributes.each do |atr|
+        selector = "[for=service_provider_attribute_bundle_#{atr}]"
+        expect(page).to have_selector(selector, wait: 0.1)
+      end
+      ial2_attributes.each do |atr|
+        selector = "[for=service_provider_attribute_bundle_#{atr}]"
+        expect(page).to_not have_selector(selector, wait: 0.1)
+      end
+    end
+
+    scenario 'IAL2 attributes shown when IAL2 is selected', :js do
+      user = create(:user)
+      login_as(user)
+
+      visit new_service_provider_path
+      select('Identity Verification permitted', from: 'Level of Service')
+
+      attributes =
+       %w[email all_emails verified_at x509_subject x509_presented first_name last_name dob ssn address1 address2 city state zipcode phone]
+
+      attributes.each do |atr|
+        selector = "[for=service_provider_attribute_bundle_#{atr}]"
+        expect(page).to have_selector(selector, wait: 0.1)
+      end
     end
     # rubocop:enable Layout/LineLength
   end


### PR DESCRIPTION
This commit starts converting some of the functionality in the service provider form to vanilla JS. This is intended to allow us to drop jQuery as a dep from the dashboard.