### PR TITLE
[WIP] Show return_to_sp_url field for all protocols in service provider forms

### DIFF
--- a/app/javascript/app/service-provider-form.js
+++ b/app/javascript/app/service-provider-form.js
@@ -1,6 +1,6 @@
 const showElement = (element) => element.classList.remove('display-none');
 const hideElement = (element) => element.classList.add('display-none');
-
+  /* eslint no-console: ["error", { allow: ["warn", "error", "log"] }] */
 function ialOptionSetup() {
   // Selectors
   const ialLevel = document.getElementById('service_provider_ial');
@@ -54,14 +54,37 @@ function protocolOptionSetup() {
   const samlFields = document.querySelectorAll('.saml-fields');
   const oidcFields = document.querySelectorAll('.oidc-fields');
   const returnToSpUrl = document.getElementById('service_provider_return_to_sp_url');
+  const returnToSpUrlLabel = returnToSpUrl.previousSibling;
+  const abbrElement = document.createElement("ABBR");
+  const requiredText = document.createTextNode("(*required)");
 
-  // Functions
+  // Functions //
+
+  // Removes required form validations that were set in simple_form for protocols that don't require the attribute
+  const removeRequiredReturnUrlValidation = () => {
+    returnToSpUrl.removeAttribute('required');
+    returnToSpUrlLabel.classList.remove('usa-input-required', 'required');
+    returnToSpUrlLabel.removeChild(returnToSpUrlLabel.lastElementChild); // this removes the abbr element that contains the "required" text from the field
+  };
+
+  const addRequiredReturnUrlValidation = () => {
+    returnToSpUrl.setAttribute('required', 'required');
+    returnToSpUrlLabel.classList.add('usa-input-required', 'required');
+    abbrElement.setAttribute("class", "text-secondary-dark");
+    abbrElement.appendChild(requiredText);
+    returnToSpUrlLabel.appendChild(abbrElement);
+  };
+
   const toggleSAMLOptions = () => {
+    if (!returnToSpUrlLabel.lastElementChild) {
+      addRequiredReturnUrlValidation();
+    }
     samlFields.forEach(showElement);
     oidcFields.forEach(hideElement);
   };
 
   const toggleOIDCOptions = () => {
+    removeRequiredReturnUrlValidation();
     oidcFields.forEach(showElement);
     samlFields.forEach(hideElement);
   };
@@ -69,13 +92,13 @@ function protocolOptionSetup() {
   const toggleFormFields = (protocol) => {
     switch (protocol) {
       case 'openid_connect_private_key_jwt':
+        toggleOIDCOptions();
+        break;
       case 'openid_connect_pkce':
         toggleOIDCOptions();
-        returnToSpUrl.removeAttribute('required');
         break;
       case 'saml':
         toggleSAMLOptions();
-        returnToSpUrl.setAttribute('required', 'required');
         break;
       default:
         samlFields.forEach(showElement);

--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -265,17 +265,15 @@ B7xxt8BVc69rHV15A0qyx77CLSj3tCx2IUXVqRs5mlvA==
                                       item_wrapper_tag: :li) do |b| %>
       <%=  b.radio_button(class: "usa-radio__input") %>
       <%=  b.label(class: "usa-radio__label")%>
-    <% end %>  
+    <% end %>
   </div>
 
-  <div class='saml-fields'>
-    <%= form.input :return_to_sp_url,
+  <%= form.input :return_to_sp_url,
                   input_html: { class: 'usa-input' },
                   label_html: { class: 'usa-input-required'},
                   label: 'Return to App URL',
                   required: true,
                   hint: I18n.t('service_provider_form.return_to_app_url').html_safe %>
-  </div>
   <%= form.input :failure_to_proof_url,
                  input_html: { class: 'usa-input' },
                  label: 'Failure to Proof URL',

--- a/app/views/service_providers/show.html.erb
+++ b/app/views/service_providers/show.html.erb
@@ -116,47 +116,47 @@
 
 <% if service_provider.identity_protocol == 'saml' %>
   <h2 class="margin-bottom-0">
-    <label for="acs_url">Assertion Consumer Service URL:</label> 
+    <label for="acs_url">Assertion Consumer Service URL:</label>
     <span class="font-mono-xs margin-left-5"><%= service_provider.acs_url %></span>
   </h2>
   <p><i> <%= I18n.t('service_provider_form.assertion_consumer_service_url').html_safe %> </i></p>
   <hr>
 
   <h2 class="margin-bottom-0">
-    <label for="assertion_consumer_logout_service_url">Assertion Consumer Logout Service URL:</label> 
+    <label for="assertion_consumer_logout_service_url">Assertion Consumer Logout Service URL:</label>
     <span class="font-mono-xs margin-left-5"><%= service_provider.assertion_consumer_logout_service_url %></span>
   </h2>
   <p><i> <%= I18n.t('service_provider_form.assertion_consumer_logout_service_url').html_safe %> </i></p>
   <hr>
 
   <h2 class="margin-bottom-0">
-    <label for="assertion_consumer_logout_service_url">SP Initiated Login URL:</label> 
+    <label for="assertion_consumer_logout_service_url">SP Initiated Login URL:</label>
     <span class="font-mono-xs margin-left-5"><%= service_provider.sp_initiated_login_url %></span>
   </h2>
   <p><i> <%= I18n.t('service_provider_form.sp_initiated_login_url').html_safe %> </i></p>
   <hr>
 
   <h2 class="margin-bottom-0">
-    <label for="block_encryption">SAML Assertion Encryption:</label> 
+    <label for="block_encryption">SAML Assertion Encryption:</label>
     <span class="font-mono-xs margin-left-5"><%= service_provider.block_encryption %></span>
   </h2>
   <p><i> <%= I18n.t('service_provider_form.saml_assertion_encryption') %> </i></p>
   <hr>
 
   <h2 class="margin-bottom-0">
-    <label for="signed_response_message_requested">Signed Response Message Requested:</label> 
+    <label for="signed_response_message_requested">Signed Response Message Requested:</label>
     <span class="font-mono-xs margin-left-5"><%= service_provider.signed_response_message_requested? ? 'Yes' : 'No' %></span>
   </h2>
   <p><i> <%= I18n.t('service_provider_form.signed_response_requested') %> </i></p>
   <hr>
-                                                                  
-  <h2 class="margin-bottom-0">
-    <label for="return_to_sp_url">Return to App URL: </label>
-    <span class="font-mono-xs margin-left-5"><%= service_provider.return_to_sp_url %></span>
-  </h2>
-  <p><i> <%= I18n.t('service_provider_form.return_to_app_url').html_safe %> </i></p>
-  <hr>
 <% end %>
+
+<h2 class="margin-bottom-0">
+  <label for="return_to_sp_url">Return to App URL: </label>
+  <span class="font-mono-xs margin-left-5"><%= service_provider.return_to_sp_url %></span>
+</h2>
+<p><i> <%= I18n.t('service_provider_form.return_to_app_url').html_safe %> </i></p>
+<hr>
 
 <h2>
   <label>Public certificates:</label>
@@ -194,14 +194,14 @@
 <hr>
 
 <h2 class="margin-bottom-0">
-  <label for="attribute_bundle">Attribute bundle:</label> 
+  <label for="attribute_bundle">Attribute bundle:</label>
   <span class="font-mono-xs margin-left-5"><%= sp_attribute_bundle(service_provider) %></span>
 </h2>
 <p><i> <%= I18n.t('service_provider_form.attribute_bundle').html_safe %> </i></p>
 <hr>
 
 <h2 class="margin-bottom-0">
-  <label for="active">Active:</label> 
+  <label for="active">Active:</label>
   <span class="font-mono-xs"><%= service_provider.active? ? 'Yes' : 'No' %></span>
 </h2>
 <hr>

--- a/spec/features/service_providers_spec.rb
+++ b/spec/features/service_providers_spec.rb
@@ -257,7 +257,7 @@ feature 'Service Providers CRUD' do
       choose('service_provider_identity_protocol_openid_connect_private_key_jwt', allow_label_click: true)
 
       saml_attributes =
-        %w[acs_url assertion_consumer_logout_service_url sp_initiated_login_url return_to_sp_url block_encryption signed_response_message_requested]
+        %w[acs_url assertion_consumer_logout_service_url sp_initiated_login_url block_encryption signed_response_message_requested]
       saml_attributes.each do |atr|
         expect(page).to_not have_content(t("simple_form.labels.service_provider.#{atr}"))
       end


### PR DESCRIPTION
### Relevant Ticket or Conversation:
I noticed something was up when I was [examining a service provider configuration](https://dashboard.int.identitysandbox.gov/service_providers/1699) and saw that the `return_to_sp_url` was populated in the yaml block at the bottom of the page, but I saw no "Return to app url" field showing on the same page. If that attribute is set, I would expect the field to show up.

### Description of Changes:
My understanding of the `return_to_sp_url` attribute is that it can be set with any protocol - looking at idp code confirms that for me. And it makes sense, since it's more of a UX setting than anything protocol-related. 

There were changes introduced ([1] [2]) in November 2021 that identified `return_to_sp_url` as a SAML-specific attribute, which isn't the case. There was also updates to the form to make `return_to_sp_url` a required field for the SAML protocol only (as far as I know, that was the intention).

I updated the service_provider form and show page HTML to declassify this field as a saml-field, so that it shows up no matter which protocol is selected. I also updated the event-listener toggle functions for the protocol radio buttons, so that the form only requires the field to be filled in on submit for the SAML protocol configurations.

Big caveat to all of this is that I could be wrong about my assumptions for how this should work.

[1]: https://github.com/18F/identity-dashboard/commit/1a2f7c95b6b5bc160e0fea4d418e3fbb7deb1b4c#diff-99ef76b66faaa43293c7866031bd1936cf873fdee66d973c6cb8cfafa752479fR84-L95
[2]: https://github.com/18F/identity-dashboard/pull/485

### PR Checklist:

1. [x] Have you linted and tested your code locally prior to submission?
2. [x] Have you tagged the appropriate dev(s) for review?
3. [x] Have you linked to any relevant tickets or conversations?

### PR Review Standards: 
- Consider using [Conventional Comments](https://conventionalcomments.org/) to ensure that your feedback is clear and actionable.
- Ideally, PRs should be reviewed by at least 2 team members.
- All PRs must be approved before being merged. 
