### PR TITLE
Turn the sign in button back into a link

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -136,7 +136,7 @@
               </li>
               <% else %>
               <li class="usa-nav__primary-item">
-                <%= button_to t('links.sign_in'), '/auth/logindotgov', method: :post, class: 'usa-button' %>
+                <%= link_to t('links.sign_in'), '/auth/logindotgov', method: :post, class: 'usa-nav__link usa-current' %>
               </li>
             <% end %>
           </ul>


### PR DESCRIPTION
**Why**: Clicking the button sign and making a post request that redirects to the IDP violates the dashboards CSP
