### PR TITLE
Use regex for checking email domains

### DIFF
--- a/app/helpers/team_helper.rb
+++ b/app/helpers/team_helper.rb
@@ -1,19 +1,19 @@
 module TeamHelper
-  WHITELISTED_DOMAINS = %w[.mil .gov .fed.us].freeze
+  ALLOWED_DOMAINS = /@*.mil|@*.gov|@*.fed.us|@*state.*.us/
 
   def can_edit_teams?(user)
     !user.teams.empty? || user.admin?
   end
 
   def can_create_teams?(user)
-    whitelisted_user? || user.admin?
+    allowed_email? || user.admin?
   end
 
   def can_delete_team?(user)
     user.admin?
   end
 
-  def whitelisted_user?
-    WHITELISTED_DOMAINS.any? { |domain| current_user.email.end_with? domain }
+  def allowed_email?
+    ALLOWED_DOMAINS.match?(current_user.email)
   end
 end

--- a/app/helpers/team_helper.rb
+++ b/app/helpers/team_helper.rb
@@ -1,5 +1,5 @@
 module TeamHelper
-  ALLOWED_DOMAINS = /@*.mil|@*.gov|@*.fed.us|@*state.*.us/
+  ALLOWED_DOMAINS = /@.+\.(mil|gov|fed\.us|state\..+\.us)$/
 
   def can_edit_teams?(user)
     !user.teams.empty? || user.admin?

--- a/app/policies/team_policy.rb
+++ b/app/policies/team_policy.rb
@@ -29,11 +29,11 @@ class TeamPolicy < BasePolicy
   end
 
   def create?
-    whitelisted_user? || admin?
+    allowed_email? || admin?
   end
 
   def new?
-    whitelisted_user? || admin?
+    allowed_email? || admin?
   end
 
   def all?

--- a/app/views/home/authenticated/index.html.erb
+++ b/app/views/home/authenticated/index.html.erb
@@ -1,4 +1,4 @@
-<% if whitelisted_user? %>
+<% if allowed_email? %>
   <div class="usa-alert usa-alert--info">
     <div class="usa-alert__body">
       <p class="usa-alert__text">You can now create teams.</p>
@@ -7,7 +7,7 @@
 <% end %>
 
 <h1 class="usa-display">Hello</h1>
-<% if whitelisted_user? %>
+<% if allowed_email? %>
   <p class='usa-intro'>Let's integrate apps with login.gov</p>
 <% elsif current_user.admin? %>
   <p class='usa-intro'>Let's help our Partners integrate apps with login.gov</p>
@@ -20,7 +20,7 @@
         new_team_path,
         method: :get,
         class: "usa-button margin-top-4 margin-bottom-4",
-        ) if whitelisted_user?
+        ) if allowed_email?
   %>
   <h1 class='margin-bottom-3'>My teams</h1>
   <%= render 'teams/teams_list' %>

--- a/spec/helpers/team_helper_spec.rb
+++ b/spec/helpers/team_helper_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 describe TeamHelper do
   let(:user) { build(:user) }
+  let!(:current_user) { user }
+
   describe '#can_edit_teams?' do
     it "returns false if user doesn't have a team" do
       expect(can_edit_teams?(user)).to eq(false)
@@ -18,6 +20,12 @@ describe TeamHelper do
       user.save
 
       expect(can_edit_teams?(user)).to eq(true)
+    end
+  end
+
+  describe '#allowed_email?' do
+    it 'allows expected emails' do
+      expect(allowed_email?).to be false
     end
   end
 end


### PR DESCRIPTION
### Description of Changes:

- Regex will allow us to accept all `state.*.us` email addresses. These domains are earmarked for states and are official government domains that we should allow.

- Also improves the description for the method that checks the domain of a prospective user's email address.

### PR Checklist:

1. [ ] Have you linted and tested your code locally prior to submission?
2. [ ] Have you tagged the appropriate dev(s) for review?
3. [ ] Have you linked to any relevant tickets or conversations?

### PR Review Standards: 
- Consider using [Conventional Comments](https://conventionalcomments.org/) to ensure that your feedback is clear and actionable.
- Ideally, PRs should be reviewed by at least 2 team members.
- All PRs must be approved before being merged. 
