### PR TITLE
Quick Fix simplify team/users queries

### DIFF
--- a/app/controllers/teams/users_controller.rb
+++ b/app/controllers/teams/users_controller.rb
@@ -24,7 +24,7 @@ class Teams::UsersController < AuthenticatedController
 
   def destroy
     if user_present_not_current_user(user)
-      team_and_users.users.delete(user)
+      team.users.delete(user)
       flash[:success] = I18n.t('teams.users.remove.success', email: user.email)
       redirect_to new_team_user_path
     else
@@ -43,7 +43,7 @@ class Teams::UsersController < AuthenticatedController
   end
 
   def user
-    @user ||= Team.includes(:users).find(params[:team_id]).users.find_by(id: params[:id])
+    @user ||= team.users.find_by(id: params[:id])
   end
 
   def user_present_not_current_user(user)
@@ -54,11 +54,7 @@ class Teams::UsersController < AuthenticatedController
     params.require(:user).permit(:email)
   end
 
-  def team_and_users
-    @team ||= Team.includes(:users).find(params[:team_id])
-  end
-
   def team
-    @team ||= Team.find(params[:team_id])
+    @team ||= Team.includes(:users).find(params[:team_id])
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,7 +5,7 @@ development: &default
   min_messages: warning
   pool: <%= IdentityConfig.store.db_pool %>
   reaping_frequency: <%= IdentityConfig.store.dp_reaping_frequency %>
-  timeout: 10000
+  timeout: 5000
   host: localhost
 
 test:

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,7 +5,7 @@ development: &default
   min_messages: warning
   pool: <%= IdentityConfig.store.db_pool %>
   reaping_frequency: <%= IdentityConfig.store.dp_reaping_frequency %>
-  timeout: 5000
+  timeout: 10000
   host: localhost
 
 test:


### PR DESCRIPTION
### Relevant Ticket or Conversation:

This is not a ticket but something I realized while chatting with Oren that I misunderstood from earlier code review ([regarding queries for team and user in users.controller.rb](https://github.com/18F/identity-dashboard/pull/607/files#r1082075398))

### Description of Changes:

Removing team_and_users method, adding includes(:users) to team method, and updating user method to use team method. Basically a little bit of cleanup

### PR Checklist:

1. [x] Have you linted and tested your code locally prior to submission?
2. [x] Have you tagged the appropriate dev(s) for review?
3. [x] Have you linked to any relevant tickets or conversations?

### PR Review Standards: 
- Consider using [Conventional Comments](https://conventionalcomments.org/) to ensure that your feedback is clear and actionable.
- Ideally, PRs should be reviewed by at least 2 team members.
- All PRs must be approved before being merged. 
