### PR TITLE
Refuse Dashboard access to users who can't create teams and are not member of any teams

### DIFF
--- a/app/controllers/users/omniauth_controller.rb
+++ b/app/controllers/users/omniauth_controller.rb
@@ -6,7 +6,7 @@ module Users
       omniauth_info = request.env['omniauth.auth']['info']
       @user = UserSession.new(omniauth_info).call
 
-      if @user && can_edit_teams?(@user)
+      if @user && ( can_edit_teams?(@user) || can_create_teams?(@user) )
         sign_in @user
         store_id_token
         redirect_to session[:requested_url]

--- a/app/helpers/team_helper.rb
+++ b/app/helpers/team_helper.rb
@@ -6,14 +6,14 @@ module TeamHelper
   end
 
   def can_create_teams?(user)
-    whitelisted_user? || user.admin?
+    whitelisted_user?(user) || user.admin?
   end
 
   def can_delete_team?(user)
     user.admin?
   end
 
-  def whitelisted_user?
-    WHITELISTED_DOMAINS.any? { |domain| current_user.email.end_with? domain }
+  def whitelisted_user?(user)
+    WHITELISTED_DOMAINS.any? { |domain| user.email.end_with? domain }
   end
 end

--- a/app/policies/team_policy.rb
+++ b/app/policies/team_policy.rb
@@ -29,11 +29,11 @@ class TeamPolicy < BasePolicy
   end
 
   def create?
-    whitelisted_user? || admin?
+    whitelisted_user?(current_user) || admin?
   end
 
   def new?
-    whitelisted_user? || admin?
+    whitelisted_user?(current_user) || admin?
   end
 
   def all?

--- a/app/views/home/authenticated/index.html.erb
+++ b/app/views/home/authenticated/index.html.erb
@@ -1,4 +1,4 @@
-<% if whitelisted_user? %>
+<% if whitelisted_user?(current_user) %>
   <div class="usa-alert usa-alert--info">
     <div class="usa-alert__body">
       <p class="usa-alert__text">You can now create teams.</p>
@@ -7,7 +7,7 @@
 <% end %>
 
 <h1 class="usa-display">Hello</h1>
-<% if whitelisted_user? %>
+<% if whitelisted_user?(current_user) %>
   <p class='usa-intro'>Let's integrate apps with login.gov</p>
 <% elsif current_user.admin? %>
   <p class='usa-intro'>Let's help our Partners integrate apps with login.gov</p>
@@ -20,7 +20,7 @@
         new_team_path,
         method: :get,
         class: "usa-button margin-top-4 margin-bottom-4",
-        ) if whitelisted_user?
+        ) if whitelisted_user?(current_user)
   %>
   <h1 class='margin-bottom-3'>My teams</h1>
   <%= render 'teams/teams_list' %>


### PR DESCRIPTION
### Relevant Ticket or Conversation:
https://cm-jira.usa.gov/browse/LG-8717
### Description of Changes:
Users that are not part of any teams and can't create teams are denied access to the Dashboard until someone adds them to a team.
### PR Checklist:

1. [X] Have you linted and tested your code locally prior to submission?
2. [X] Have you tagged the appropriate dev(s) for review?
3. [X] Have you linked to any relevant tickets or conversations?

### PR Review Standards: 
- Consider using [Conventional Comments](https://conventionalcomments.org/) to ensure that your feedback is clear and actionable.
- Ideally, PRs should be reviewed by at least 2 team members.
- All PRs must be approved before being merged. 
