### PR TITLE
LG-9180: Add font-weight to app name and friendly name fields

### DIFF
--- a/app/assets/stylesheets/application.css.scss.erb
+++ b/app/assets/stylesheets/application.css.scss.erb
@@ -159,3 +159,7 @@ $image-path: 'img';
   border-bottom-right-radius: 0;
   max-width: 12rem;
 }
+
+.text-heavy {
+  font-weight: 800;
+}

--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -21,13 +21,13 @@
                  input_html: { class: 'usa-input' },
                  label_html: { class: 'usa-input-required'},
                  label: 'App name',
-                 hint: I18n.t('service_provider_form.app_name') %>
+                 hint: I18n.t('service_provider_form.app_name').html_safe %>
 
   <%= form.input :friendly_name,
                  input_html: { class: 'usa-input' },
                  label_html: { class: 'usa-input-required'},
                  label: 'Friendly name',
-                 hint: I18n.t('service_provider_form.friendly_name') %>
+                 hint: I18n.t('service_provider_form.friendly_name').html_safe %>
 
 
   <%= form.input :description,

--- a/config/locales/service_providers.en.yml
+++ b/config/locales/service_providers.en.yml
@@ -1,8 +1,8 @@
 ---
 en:
   service_provider_form:
-    app_name: "The name of your application as it appears in the signed Inter-Agency Agreement with Login.gov. Ex: DHS - CSP"
-    friendly_name: "The name of your app that will get displayed to users when logging in. Ex: DHS Customer Service Portal"
+    app_name: "The name of your application <span class='text-heavy'>as it appears in the signed Inter-Agency Agreement (IAA)</span> with Login.gov. Ex: DHS - CSP"
+    friendly_name: "The name of your app that will be <span class='text-heavy'>displayed to users</span> when logging in. Example: DHS Customer Service Portal"
     description: "A description of the app (may be helpful for your colleagues)."
     team: "Assign an agency team to this client."
     protocol: "This is the authentication protocol used by the service provider. We highly recommend using OpenID Connect, unless a technical reason prevents you."


### PR DESCRIPTION
### Relevant Ticket or Conversation:
https://cm-jira.usa.gov/browse/LG-9180

### Description of Changes:

Adding a `text-heavy` class, and applying it to two field hints for the service_provider form.

### PR Checklist:

1. [x] Have you linted and tested your code locally prior to submission?
2. [x] Have you tagged the appropriate dev(s) for review?
3. [x] Have you linked to any relevant tickets or conversations?

### PR Review Standards: 
- Consider using [Conventional Comments](https://conventionalcomments.org/) to ensure that your feedback is clear and actionable.
- Ideally, PRs should be reviewed by at least 2 team members.
- All PRs must be approved before being merged. 
