### PR TITLE
Replace deprecated USWDS v1 form hint class

### DIFF
--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -44,7 +44,7 @@ SimpleForm.setup do |config|
     b.use :label, class: 'usa-label'
     # changed input class from field to usa-input
     b.use :input, class: 'block col-12' # usa-input'
-    b.use :hint,  wrap_with: { tag: 'div', class: 'usa-form-hint' }
+    b.use :hint,  wrap_with: { tag: 'div', class: 'usa-hint' }
     b.use :error, wrap_with: { tag: 'div', class: 'usa-error-message' }
   end
 


### PR DESCRIPTION
### Description of Changes:

Replaces `.usa-form-hint` with `.usa-hint`.

`.usa-form-hint` is a legacy class name from USWDS v1, replaced in USWDS v2 with `.usa-hint` ([documentation](https://designsystem.digital.gov/documentation/migration-v2/#inputs)).

We still define custom styles for this class in the Login.gov Design System ([source](https://github.com/18F/identity-style-guide/blob/4b8c38eccb0ddec64a3d87ce76cc31f07a4c56a0/src/scss/components/_inputs.scss#L233-L237)), but I'd like to remove these styles, and this appears to the only instance in use I could find.

This **does** have a visual impact, but it is intended to bring into alignment with hints on other Login.gov sites. If needed, we could add additional utility classes to restore the original style.

**Effective styles:**

_Before:_

```css
.usa-form-hint {
    padding-top: 0.25rem;
    padding-bottom: 0.25rem;
    display: inline-block;
}
```

_After:_

```css
.usa-hint {
    color: #767676;
}
```

**Screenshots:**

Before|After
---|---
![localhost_3001_service_providers_new_ (1)](https://user-images.githubusercontent.com/1779930/232132927-8a63de58-7258-44ac-83d5-f70af8f02d1f.png)|![localhost_3001_service_providers_new_](https://user-images.githubusercontent.com/1779930/232132923-918ff0e2-1054-4f94-9171-a868b5ac68e8.png)
