### PR TITLE
Move saml_idp to default gem group so it can be used in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'redacted_struct'
 gem 'responders', '~> 3.0', '>= 3.0.1'
 gem 'rest-client', '~> 2.1'
 gem 'ruby_regex'
+gem 'saml_idp', git: 'https://github.com/18F/saml_idp.git', tag: '0.18.1-18f'
 gem 'sass-rails', '~> 6.0', '>= 6.0.0'
 gem 'secure_headers', '~> 3.9'
 gem 'simple_form', '~> 5.1', '>= 5.1.0'
@@ -68,7 +69,6 @@ group :development, :test do
   gem 'rubocop', '~> 1.11.0'
   gem 'rubocop-rails', '~> 2.5.2'
   gem 'rubocop-rspec'
-  gem 'saml_idp', git: 'https://github.com/18F/saml_idp.git', tag: '0.18.1-18f'
 end
 
 group :test do


### PR DESCRIPTION
### Relevant Ticket or Conversation:

### Description of Changes:
#630 added the `saml_idp`, but only in test/dev environments, so the application crashes when reaching this [line](https://github.com/18F/identity-dashboard/blob/258ada40bfb761376f735afe1de3050e074d6f67/app/controllers/tools_controller.rb#L2) when deployed in production.

This PR moves the gem into the default group.
### PR Checklist:

1. [ ] Have you linted and tested your code locally prior to submission?
2. [ ] Have you tagged the appropriate dev(s) for review?
3. [ ] Have you linked to any relevant tickets or conversations?

### PR Review Standards: 
- Consider using [Conventional Comments](https://conventionalcomments.org/) to ensure that your feedback is clear and actionable.
- Ideally, PRs should be reviewed by at least 2 team members.
- All PRs must be approved before being merged. 
