### PR TITLE
Fix N+1 query on logos for service_providers API endpoint

### DIFF
--- a/app/controllers/api/service_providers_controller.rb
+++ b/app/controllers/api/service_providers_controller.rb
@@ -25,7 +25,7 @@ module Api
     end
 
     def approved_service_providers
-      ServiceProvider.includes(:logo_file_attachment, :agency).all
+      ServiceProvider.includes(logo_file_attachment: :blob).includes(:agency).all
     end
   end
 end

--- a/app/controllers/api/service_providers_controller.rb
+++ b/app/controllers/api/service_providers_controller.rb
@@ -25,7 +25,7 @@ module Api
     end
 
     def approved_service_providers
-      ServiceProvider.includes(logo_file_attachment: :blob).includes(:agency).all
+      ServiceProvider.includes(:agency, logo_file_attachment: :blob).all
     end
   end
 end


### PR DESCRIPTION
### Relevant Ticket or Conversation:

### Description of Changes:
There's currently an N+1 query that causes us to hit the active_storage_blobs table for each row in service_providers (could be hundreds of individual queries). This change adds that table to the preload so that it is all loaded in one query.

```
D, [2023-04-27T19:34:18.909681 #12917] DEBUG -- :   ActiveStorage::Blob Load (0.8ms)  SELECT "active_storage_blobs".* FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = $1 LIMIT $2  [["id", 2677], ["LIMIT", 1]]
D, [2023-04-27T19:34:18.911386 #12917] DEBUG -- :   ActiveStorage::Blob Load (0.7ms)  SELECT "active_storage_blobs".* FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = $1 LIMIT $2  [["id", 1490], ["LIMIT", 1]]
D, [2023-04-27T19:34:18.913152 #12917] DEBUG -- :   ActiveStorage::Blob Load (0.6ms)  SELECT "active_storage_blobs".* FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = $1 LIMIT $2  [["id", 1382], ["LIMIT", 1]]
D, [2023-04-27T19:34:18.914638 #12917] DEBUG -- :   ActiveStorage::Blob Load (0.6ms)  SELECT "active_storage_blobs".* FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = $1 LIMIT $2  [["id", 2593], ["LIMIT", 1]]
D, [2023-04-27T19:34:18.916546 #12917] DEBUG -- :   ActiveStorage::Blob Load (0.6ms)  SELECT "active_storage_blobs".* FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = $1 LIMIT $2  [["id", 2102], ["LIMIT", 1]]
D, [2023-04-27T19:34:18.917967 #12917] DEBUG -- :   ActiveStorage::Blob Load (0.5ms)  SELECT "active_storage_blobs".* FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = $1 LIMIT $2  [["id", 2044], ["LIMIT", 1]]
D, [2023-04-27T19:34:18.919227 #12917] DEBUG -- :   ActiveStorage::Blob Load (0.5ms)  SELECT "active_storage_blobs".* FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = $1 LIMIT $2  [["id", 2177], ["LIMIT", 1]]
D, [2023-04-27T19:34:18.920912 #12917] DEBUG -- :   ActiveStorage::Blob Load (0.7ms)  SELECT "active_storage_blobs".* FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = $1 LIMIT $2  [["id", 2119], ["LIMIT", 1]]
D, [2023-04-27T19:34:18.922321 #12917] DEBUG -- :   ActiveStorage::Blob Load (0.6ms)  SELECT "active_storage_blobs".* FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = $1 LIMIT $2  [["id", 248], ["LIMIT", 1]]
D, [2023-04-27T19:34:18.923923 #12917] DEBUG -- :   ActiveStorage::Blob Load (0.7ms)  SELECT "active_storage_blobs".* FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = $1 LIMIT $2  [["id", 251], ["LIMIT", 1]]
D, [2023-04-27T19:34:18.925120 #12917] DEBUG -- :   ActiveStorage::Blob Load (0.5ms)  SELECT "active_storage_blobs".* FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = $1 LIMIT $2  [["id", 252], ["LIMIT", 1]]
D, [2023-04-27T19:34:18.926499 #12917] DEBUG -- :   ActiveStorage::Blob Load (0.5ms)  SELECT "active_storage_blobs".* FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = $1 LIMIT $2  [["id", 254], ["LIMIT", 1]]
D, [2023-04-27T19:34:18.927582 #12917] DEBUG -- :   ActiveStorage::Blob Load (0.5ms)  SELECT "active_storage_blobs".* FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = $1 LIMIT $2  [["id", 255], ["LIMIT", 1]]
D, [2023-04-27T19:34:18.928659 #12917] DEBUG -- :   ActiveStorage::Blob Load (0.5ms)  SELECT "active_storage_blobs".* FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = $1 LIMIT $2  [["id", 1854], ["LIMIT", 1]]
D, [2023-04-27T19:34:18.929770 #12917] DEBUG -- :   ActiveStorage::Blob Load (0.4ms)  SELECT "active_storage_blobs".* FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = $1 LIMIT $2  [["id", 250], ["LIMIT", 1]]
D, [2023-04-27T19:34:18.930923 #12917] DEBUG -- :   ActiveStorage::Blob Load (0.5ms)  SELECT "active_storage_blobs".* FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = $1 LIMIT $2  [["id", 253], ["LIMIT", 1]]
D, [2023-04-27T19:34:18.932198 #12917] DEBUG -- :   ActiveStorage::Blob Load (0.5ms)  SELECT "active_storage_blobs".* FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = $1 LIMIT $2  [["id", 1694], ["LIMIT", 1]]
D, [2023-04-27T19:34:18.933554 #12917] DEBUG -- :   ActiveStorage::Blob Load (0.5ms)  SELECT "active_storage_blobs".* FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = $1 LIMIT $2  [["id", 247], ["LIMIT", 1]]
# ...
```

becomes

```
D, [2023-04-27T19:39:09.758936 #12917] DEBUG -- :   ActiveStorage::Blob Load (1.0ms)  SELECT "active_storage_blobs".* FROM "active_storage_blobs"
WHERE "active_storage_blobs"."id" IN ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41)
```
### PR Checklist:

1. [x] Have you linted and tested your code locally prior to submission?
2. [x] Have you tagged the appropriate dev(s) for review?
3. [ ] Have you linked to any relevant tickets or conversations?

### PR Review Standards: 
- Consider using [Conventional Comments](https://conventionalcomments.org/) to ensure that your feedback is clear and actionable.
- Ideally, PRs should be reviewed by at least 2 team members.
- All PRs must be approved before being merged. 
