### PR TITLE
Make strings that have HTML to render as HTML

### DIFF
--- a/app/views/service_providers/show.html.erb
+++ b/app/views/service_providers/show.html.erb
@@ -13,14 +13,14 @@
   <label for="name">App name: </label>
   <span class="font-mono-xs margin-left-5"><%= service_provider.app_name %></span>
 </h2>
-<p><i> <%= I18n.t('service_provider_form.app_name') %> </i></p>
+<p><i> <%= sanitize I18n.t('service_provider_form.app_name') %> </i></p>
 <hr>
 
 <h2 class="margin-bottom-0">
   <label for="name">Friendly name:</label>
   <span class="font-mono-xs margin-left-5"><%= service_provider.friendly_name %></span>
 </h2>
-<p><i> <%= I18n.t('service_provider_form.friendly_name') %> </i></p>
+<p><i> <%= sanitize I18n.t('service_provider_form.friendly_name') %> </i></p>
 <hr>
 
 <h2 class="margin-bottom-0">


### PR DESCRIPTION
### Description of Changes:

Some of our internalization strings include HTML but weren't being rendered in HTML. This will force Ruby to render the HTML instead of just printing it out to the user.

### Screenshots

Before:
<img width="1025" alt="image" src="https://github.com/18F/identity-dashboard/assets/2308626/1b29e701-044f-4cee-b103-02fdd9ac5493">

After:
<img width="947" alt="image" src="https://github.com/18F/identity-dashboard/assets/2308626/fbc2e9ca-9269-4834-857d-b399ef96cf26">

### PR Checklist:

1. [X] Have you linted and tested your code locally prior to submission?
2. [ ] Have you tagged the appropriate dev(s) for review?
3. [X] Have you linked to any relevant tickets or conversations?

### PR Review Standards: 
- Consider using [Conventional Comments](https://conventionalcomments.org/) to ensure that your feedback is clear and actionable.
- Ideally, PRs should be reviewed by at least 2 team members.
- All PRs must be approved before being merged. 
