### PR TITLE
Revert "update serializer to include protocol"

### DIFF
--- a/app/serializers/service_provider_serializer.rb
+++ b/app/serializers/service_provider_serializer.rb
@@ -13,7 +13,6 @@ class ServiceProviderSerializer < ActiveModel::Serializer
     :default_aal,
     :issuer,
     :logo,
-    :protocol,
     :remote_logo_key,
     :redirect_uris,
     :return_to_sp_url,
@@ -37,14 +36,6 @@ class ServiceProviderSerializer < ActiveModel::Serializer
 
   def certs
     object.certificates.map(&:to_pem)
-  end
-
-  def protocol
-    if object['identity_protocol'] == 'saml'
-      'saml'
-    else
-      'oidc'
-    end
   end
 
   def updated_at

--- a/spec/serializers/service_provider_serializer_spec.rb
+++ b/spec/serializers/service_provider_serializer_spec.rb
@@ -35,8 +35,7 @@ RSpec.describe ServiceProviderSerializer do
           eq(service_provider.email_nameid_format_allowed)
         expect(as_json[:signed_response_message_requested]).to \
           eq(service_provider.signed_response_message_requested)
-        expect(as_json[:allow_prompt_login]).to be true
-        expect(as_json[:protocol]).to eq 'oidc'
+        expect(as_json[:allow_prompt_login]).to eq(true)
       end
     end
 


### PR DESCRIPTION
[partner reports error when updating config](https://logingov.zendesk.com/agent/tickets/4123)
Missing `protocol` attribute in IdP prevents service_provider update in `sandbox`
