### PR TITLE
lg-9761 update serializer to include protocol attribute one more time with feeling

### DIFF
--- a/app/controllers/api/service_providers_controller.rb
+++ b/app/controllers/api/service_providers_controller.rb
@@ -7,7 +7,7 @@ module Api
     end
 
     def show
-      render json: ServiceProviderSerializer.new(service_provider).as_json
+      render json: ServiceProviderSerializer.new(service_provider, action: :show).as_json
     end
 
     def update

--- a/app/serializers/service_provider_serializer.rb
+++ b/app/serializers/service_provider_serializer.rb
@@ -13,6 +13,7 @@ class ServiceProviderSerializer < ActiveModel::Serializer
     :default_aal,
     :issuer,
     :logo,
+    :protocol,
     :remote_logo_key,
     :redirect_uris,
     :return_to_sp_url,
@@ -36,6 +37,14 @@ class ServiceProviderSerializer < ActiveModel::Serializer
 
   def certs
     object.certificates.map(&:to_pem)
+  end
+
+  def protocol
+    if object['identity_protocol'] == 'saml'
+      'saml'
+    else
+      'oidc'
+    end
   end
 
   def updated_at

--- a/app/serializers/service_provider_serializer.rb
+++ b/app/serializers/service_provider_serializer.rb
@@ -13,7 +13,6 @@ class ServiceProviderSerializer < ActiveModel::Serializer
     :default_aal,
     :issuer,
     :logo,
-    :protocol,
     :remote_logo_key,
     :redirect_uris,
     :return_to_sp_url,
@@ -26,6 +25,14 @@ class ServiceProviderSerializer < ActiveModel::Serializer
     :help_text,
     :allow_prompt_login,
   )
+
+  # protocol is NOT a field in identity-idp. it should not be
+  # passed to the idp via the index method.
+  attribute :protocol, if: :show
+
+  def show
+    instance_options[:action] == :show
+  end
 
   def agency
     object&.agency&.name

--- a/spec/controllers/api/service_providers_controller_spec.rb
+++ b/spec/controllers/api/service_providers_controller_spec.rb
@@ -31,16 +31,28 @@ describe Api::ServiceProvidersController do
       get :index
       expect(response_from_json).to include serialized_sp.deep_symbolize_keys
     end
+
+    it 'does not return the protocol attribute' do
+      sp = create(:service_provider, :with_team, active: true, approved: true)
+
+      get :index
+      expect(response_from_json.first.keys).to_not include :protocol
+    end
   end
 
   describe '#show' do
     let(:sp) { create(:service_provider, :with_team)}
+    before { get :show, params: {id: sp.id} }
 
     it 'returns the service provider whose params are passed in' do
-      serialized = ServiceProviderSerializer.new(sp).to_h
-      get :show, params: {id: sp.id}
+      serialized = ServiceProviderSerializer.new(sp, action: :show).to_h
 
       expect(response_from_json).to eq(serialized.deep_symbolize_keys)
+    end
+
+    it 'includes the protocol attribute' do
+
+      expect(response_from_json.keys).to include :protocol
     end
 
   end

--- a/spec/serializers/service_provider_serializer_spec.rb
+++ b/spec/serializers/service_provider_serializer_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe ServiceProviderSerializer do
           eq(service_provider.email_nameid_format_allowed)
         expect(as_json[:signed_response_message_requested]).to \
           eq(service_provider.signed_response_message_requested)
-        expect(as_json[:allow_prompt_login]).to eq(true)
+        expect(as_json[:allow_prompt_login]).to be true
+        expect(as_json[:protocol]).to eq 'oidc'
       end
     end
 

--- a/spec/serializers/service_provider_serializer_spec.rb
+++ b/spec/serializers/service_provider_serializer_spec.rb
@@ -36,12 +36,23 @@ RSpec.describe ServiceProviderSerializer do
         expect(as_json[:signed_response_message_requested]).to \
           eq(service_provider.signed_response_message_requested)
         expect(as_json[:allow_prompt_login]).to be true
-        expect(as_json[:protocol]).to eq 'oidc'
       end
     end
 
     it 'gets the agency_id from the team' do
       expect(as_json[:agency_id]).to eq(team_agency_id)
+    end
+
+    it 'there is no protocol attribute' do
+      expect(as_json.keys).to_not include :protocol
+    end
+
+
+    describe 'when the option "action: :show" is passed' do
+      subject(:serializer) { ServiceProviderSerializer.new(service_provider, action: :show) }
+      it 'passes the protocol attribute through' do
+        expect(as_json[:protocol]).to eq 'oidc'
+      end
     end
   end
 end


### PR DESCRIPTION
### Relevant Ticket or Conversation:
the first attempt to add the protocol attribute led to a bug where partners hit errors when they tried to update their config https://github.com/18F/identity-dashboard/pull/649

this time, we only pass the protocol attribute through if the serializer is being called via our show endpoint.

### Description of Changes:
added a :show option to the Serializer

### PR Checklist:

1. [ ] Have you linted and tested your code locally prior to submission?
2. [ ] Have you tagged the appropriate dev(s) for review?
3. [ ] Have you linked to any relevant tickets or conversations?

### PR Review Standards: 
- Consider using [Conventional Comments](https://conventionalcomments.org/) to ensure that your feedback is clear and actionable.
- Ideally, PRs should be reviewed by at least 2 team members.
- All PRs must be approved before being merged. 
