### PR TITLE
LG-10145 Fix bug that deletes users in update path

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -64,15 +64,19 @@ class TeamsController < AuthenticatedController
   end
 
   def team_params
-    params.require(:team).permit(:name, :agency_id, :description, user_ids: [])
+    params.require(:team).permit(:name, :agency_id, :description)
+  end
+
+  def user_params
+    params[:user_ids]&.split(' ') || []
   end
 
   def update_params_with_current_user
     if current_user.admin?
       team_params
     else
-      user_ids = team_params[:user_ids] || []
-      team_params.merge(user_ids: (user_ids << current_user.id.to_s))
+      user_ids = user_params
+      team_params.merge(user_ids: (user_ids << current_user.id.to_s).uniq)
     end
   end
 end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -67,7 +67,7 @@ class TeamsController < AuthenticatedController
     params.require(:team).permit(:name, :agency_id, :description)
   end
 
-  def user_params
+  def existing_user_ids
     params[:user_ids]&.split(' ') || []
   end
 
@@ -75,8 +75,7 @@ class TeamsController < AuthenticatedController
     if current_user.admin?
       team_params
     else
-      user_ids = user_params
-      team_params.merge(user_ids: (user_ids << current_user.id.to_s).uniq)
+      team_params.merge(user_ids: (existing_user_ids + [current_user.id.to_s]).uniq)
     end
   end
 end

--- a/app/views/teams/edit.html.erb
+++ b/app/views/teams/edit.html.erb
@@ -12,6 +12,7 @@
         <li><%= u.email %></li>
       <% end %>
     </ul>
+    <%= hidden_field_tag "user_ids", [@team.users.map(&:id)] %>
     <%= link_to(
       "Manage users",
       team_users_path(@team),

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -190,6 +190,22 @@ describe TeamsController do
           patch :update, params: { id: org.id, team: { name: org.name }, new_user: { email: '' } }
           expect(response.status).to eq(302)
         end
+
+        context 'when no update is made' do
+          let(:user1)  { create(:team_member, teams: [org])}
+          let(:user2)  { create(:team_member, teams: [org])}
+          before do
+            org.update(users: [user, user1, user2])
+          end
+
+          it 'has the same number of users after' do
+            expect(org.users.count).to eq 3
+            patch :update, params: {
+              id: org.id,
+              team: { name: org.name, agency_id: org.agency_id, description: org.description } }
+            expect(org.users.count).to eq 3
+          end
+        end
       end
 
       context 'when the update is unsuccessful' do
@@ -199,7 +215,7 @@ describe TeamsController do
 
         it 'renders the edit action' do
           patch :update, params: {
-            id: org.id, team: { name: org.name, user_ids: [user.id.to_s] }, new_user: { email: '' }
+            id: org.id, team: { name: org.name }, new_user: { email: '' }
           }
           expect(response).to render_template(:edit)
         end
@@ -211,13 +227,38 @@ describe TeamsController do
         user.admin = false
         org.users << user
       end
+
+      context 'when no update is made' do
+        let(:user1)  { create(:team_member, teams: [org])}
+        let(:user2)  { create(:team_member, teams: [org])}
+        before do
+          org.update(users: [user, user1, user2])
+        end
+
+        it 'has the same number of users after' do
+          expect(org.users.count).to eq 3
+          patch :update, params: {
+            id: org.id,
+            team: {
+              name: org.name,
+              agency_id: org.agency_id,
+              description: org.description,
+            },
+          user_ids: "#{user.id} #{user1.id} #{user2.id}" }
+          expect(org.users.count).to eq 3
+        end
+      end
     end
 
     context 'when user is neither a admin nor a team member' do
       it 'has an unauthorized response' do
         patch :update, params: {
-          id: org.id, team: { name: org.name, user_ids: [user.id.to_s] }, new_user: { email: '' }
-        }
+          id: org.id,
+          team: {
+            name: org.name,
+            agency_id: org.agency_id,
+            description: org.description,
+          } }
         expect(response.status).to eq(401)
       end
     end


### PR DESCRIPTION
### Relevant Ticket or Conversation:
https://cm-jira.usa.gov/browse/LG-10145

### Description of Changes:
When a non-admin user tried to update team information, it would delete all the users except that team member. This change adds a hidden_field_tag to pass the existing team's user ids through in order to make sure they are all present in an update.

### PR Checklist:

1. [ ] Have you linted and tested your code locally prior to submission?
2. [ ] Have you tagged the appropriate dev(s) for review?
3. [ ] Have you linked to any relevant tickets or conversations?

### PR Review Standards: 
- Consider using [Conventional Comments](https://conventionalcomments.org/) to ensure that your feedback is clear and actionable.
- Ideally, PRs should be reviewed by at least 2 team members.
- All PRs must be approved before being merged. 
