### PR TITLE
Send PKCE attribute in service providers API so it is updated in the IDP

### DIFF
--- a/app/helpers/service_provider_helper.rb
+++ b/app/helpers/service_provider_helper.rb
@@ -188,7 +188,7 @@ module ServiceProviderHelper
     if config_hash['protocol'] == 'openid_connect_pkce'
       config_hash.merge({'pkce' => true, 'protocol' => 'oidc'})
     else
-      config_hash.merge({'protocol' => 'oidc'})
+      config_hash.merge({'pkce' => false, 'protocol' => 'oidc'})
     end
   end
 end

--- a/app/serializers/service_provider_serializer.rb
+++ b/app/serializers/service_provider_serializer.rb
@@ -24,11 +24,11 @@ class ServiceProviderSerializer < ActiveModel::Serializer
     :updated_at,
     :help_text,
     :allow_prompt_login,
+    :pkce,
   )
 
   # these are attributes that should only be passed to the show
   # endpoint
-  attribute :protocol, if: :show
   attribute :pkce, if: :show
 
   def show
@@ -48,7 +48,11 @@ class ServiceProviderSerializer < ActiveModel::Serializer
   end
 
   def pkce
-    object.openid_connect_pkce?
+    if object.openid_connect_pkce?
+      true
+    else
+      false
+    end
   end
 
   def protocol

--- a/app/serializers/service_provider_serializer.rb
+++ b/app/serializers/service_provider_serializer.rb
@@ -29,7 +29,7 @@ class ServiceProviderSerializer < ActiveModel::Serializer
 
   # these are attributes that should only be passed to the show
   # endpoint
-  attribute :pkce, if: :show
+  attribute :protocol, if: :show
 
   def show
     instance_options[:action] == :show
@@ -48,7 +48,9 @@ class ServiceProviderSerializer < ActiveModel::Serializer
   end
 
   def pkce
-    if object.openid_connect_pkce?
+    if IdentityConfig.store.service_providers_with_nil_pkce.include?(object.issuer)
+      nil
+    elsif object.openid_connect_pkce?
       true
     else
       false

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -21,6 +21,7 @@ smtp_host: localhost
 smtp_password: changeme
 smtp_port: '2025'
 smtp_username: changeme
+service_providers_with_nil_pkce: ''
 
 development:
   dashboard_api_token: test_token

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -66,6 +66,7 @@ class IdentityConfig
     config.add(:saml_sp_private_key_password, type: :string)
     config.add(:secret_key_base, type: :string)
     config.add(:serve_static_files, type: :boolean)
+    config.add(:service_providers_with_nil_pkce, type: :comma_separated_string_list)
     config.add(:smtp_address, type: :string)
     config.add(:smtp_domain, type: :string)
     config.add(:smtp_host, type: :string)

--- a/spec/serializers/service_provider_serializer_spec.rb
+++ b/spec/serializers/service_provider_serializer_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe ServiceProviderSerializer do
         expect(as_json[:signed_response_message_requested]).to \
           eq(service_provider.signed_response_message_requested)
         expect(as_json[:allow_prompt_login]).to be true
+        expect(as_json[:pkce]).to eq(false)
       end
     end
 
@@ -46,11 +47,6 @@ RSpec.describe ServiceProviderSerializer do
     it 'there is no protocol attribute' do
       expect(as_json.keys).to_not include :protocol
     end
-
-    it 'there is no pkce attribute' do
-      expect(as_json.keys).to_not include :pkce
-    end
-
 
     describe 'when the option "action: :show" is passed' do
       subject(:serializer) { ServiceProviderSerializer.new(service_provider, action: :show) }


### PR DESCRIPTION
### Relevant Ticket or Conversation:

The (hopefully) final large change for [SBAR misconfiguration work](https://docs.google.com/document/d/1oi5FyJqzH-yA5nR6mC_AcDhEp-avpLoZTzYQelPoP5M/edit)

### Description of Changes:

Currently, the dashboard does not send the `pkce` attribute via the API when service providers are updated. The result of this is that all IDP environments that use the dashboard application will have service providers where the `pkce` value is always `nil`. This can be confusing and lead to issues when promoted to production though this is mitigated by [this change](https://github.com/18F/identity-idp-config/pull/1709) in the identity-idp-config repository.

- Passes true or false in the `pkce` attribute with a couple of exceptions (drawn from a similar one [here](https://github.com/18F/identity-idp-config/blob/dfd066f/lib/models/service_provider.rb#L299))

### PR Checklist:

1. [x] Have you linted and tested your code locally prior to submission?
2. [x] Have you tagged the appropriate dev(s) for review?
3. [ ] Have you linked to any relevant tickets or conversations?

### PR Review Standards: 
- Consider using [Conventional Comments](https://conventionalcomments.org/) to ensure that your feedback is clear and actionable.
- Ideally, PRs should be reviewed by at least 2 team members.
- All PRs must be approved before being merged. 
