### PR TITLE
Pass single service_provider to sync

### DIFF
--- a/app/controllers/service_providers_controller.rb
+++ b/app/controllers/service_providers_controller.rb
@@ -230,7 +230,7 @@ class ServiceProvidersController < AuthenticatedController
 
   def body_attributes
     {
-      service_provider: ServiceProviderSerializer.new(service_provider).to_json,
+      service_provider: ServiceProviderSerializer.new(service_provider)
     }
   end
 

--- a/app/controllers/service_providers_controller.rb
+++ b/app/controllers/service_providers_controller.rb
@@ -81,12 +81,12 @@ class ServiceProvidersController < AuthenticatedController
   def save_service_provider(service_provider)
     service_provider.save!
     flash[:success] = I18n.t('notices.service_provider_saved', issuer: service_provider.issuer)
-    publish_service_providers
+    publish_service_provider
     redirect_to service_provider_path(service_provider)
   end
 
-  def publish_service_providers
-    if ServiceProviderUpdater.ping == 200
+  def publish_service_provider
+    if ServiceProviderUpdater.ping({service_provider: ServiceProviderSerializer.new(service_provider).as_json})
       flash[:notice] = I18n.t('notices.service_providers_refreshed')
     else
       flash[:error] = I18n.t('notices.service_providers_refresh_failed')

--- a/app/controllers/service_providers_controller.rb
+++ b/app/controllers/service_providers_controller.rb
@@ -86,7 +86,7 @@ class ServiceProvidersController < AuthenticatedController
   end
 
   def publish_service_provider
-    if ServiceProviderUpdater.ping({service_provider: ServiceProviderSerializer.new(service_provider).as_json})
+    if ServiceProviderUpdater.ping({ service_provider: sp_attributes }) == 200
       flash[:notice] = I18n.t('notices.service_providers_refreshed')
     else
       flash[:error] = I18n.t('notices.service_providers_refresh_failed')
@@ -226,6 +226,10 @@ class ServiceProvidersController < AuthenticatedController
       end
     end
     service_provider
+  end
+
+  def sp_attributes
+    ServiceProviderSerializer.new(service_provider).as_json
   end
 
   helper_method :service_provider

--- a/app/controllers/service_providers_controller.rb
+++ b/app/controllers/service_providers_controller.rb
@@ -230,7 +230,7 @@ class ServiceProvidersController < AuthenticatedController
 
   def body_attributes
     {
-      service_provider: ServiceProviderSerializer.new(service_provider)
+      service_provider: ServiceProviderSerializer.new(service_provider),
     }
   end
 

--- a/app/controllers/service_providers_controller.rb
+++ b/app/controllers/service_providers_controller.rb
@@ -86,7 +86,7 @@ class ServiceProvidersController < AuthenticatedController
   end
 
   def publish_service_provider
-    if ServiceProviderUpdater.ping({ service_provider: sp_attributes }) == 200
+    if ServiceProviderUpdater.ping(body_attributes) == 200
       flash[:notice] = I18n.t('notices.service_providers_refreshed')
     else
       flash[:error] = I18n.t('notices.service_providers_refresh_failed')
@@ -228,8 +228,10 @@ class ServiceProvidersController < AuthenticatedController
     service_provider
   end
 
-  def sp_attributes
-    ServiceProviderSerializer.new(service_provider).as_json
+  def body_attributes
+    {
+      service_provider: ServiceProviderSerializer.new(service_provider).to_json,
+    }
   end
 
   helper_method :service_provider

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -190,7 +190,7 @@ class ServiceProvider < ApplicationRecord
     true
   end
 
-  def contains_invalid_attribute? 
+  def contains_invalid_attribute?
     possible_attributes = ALLOWED_IAL1_ATTRIBUTES + ALLOWED_IAL2_ATTRIBUTES
     attribute_bundle.any? { |att| !possible_attributes.include?(att) }
   end

--- a/app/services/service_provider_updater.rb
+++ b/app/services/service_provider_updater.rb
@@ -1,6 +1,6 @@
 class ServiceProviderUpdater
   def self.ping(body=nil)
-    resp = Faraday.post(idp_url, body, token_header)
+    resp = conn.post {|req| req.body = body.to_json if body.present? }
 
     status_code = resp.status
     return status_code if status_code == 200
@@ -14,12 +14,19 @@ class ServiceProviderUpdater
   end
 
   class << self
+    def conn
+      Faraday.new(url: idp_url, headers:)
+    end
+
     def idp_url
       IdentityConfig.store.idp_sp_url
     end
 
-    def token_header
-      { 'X-LOGIN-DASHBOARD-TOKEN' => IdentityConfig.store.dashboard_api_token }
+    def headers
+      {
+        'X-LOGIN-DASHBOARD-TOKEN' => IdentityConfig.store.dashboard_api_token,
+        'Content-Type' => 'application/json',
+      }
     end
 
     def handle_error(error)

--- a/app/services/service_provider_updater.rb
+++ b/app/services/service_provider_updater.rb
@@ -1,6 +1,6 @@
 class ServiceProviderUpdater
-  def self.ping
-    resp = Faraday.post(idp_url, nil, token_header)
+  def self.ping(body=nil)
+    resp = Faraday.post(idp_url, body, token_header)
 
     status_code = resp.status
     return status_code if status_code == 200

--- a/spec/controllers/service_providers_controller_spec.rb
+++ b/spec/controllers/service_providers_controller_spec.rb
@@ -162,7 +162,7 @@ describe ServiceProvidersController do
 
       expect(Faraday).to have_received(:post).with(
         IdentityConfig.store.idp_sp_url,
-        {service_provider: ServiceProviderSerializer.new(sp).as_json},
+        {service_provider: ServiceProviderSerializer.new(sp).to_json},
         { 'X-LOGIN-DASHBOARD-TOKEN' => IdentityConfig.store.dashboard_api_token },
       )
     end

--- a/spec/controllers/service_providers_controller_spec.rb
+++ b/spec/controllers/service_providers_controller_spec.rb
@@ -157,13 +157,13 @@ describe ServiceProvidersController do
     end
 
     it 'sends a serialized service provider to the IDP' do
-      allow(Faraday).to receive(:post).and_call_original
+      allow(ServiceProviderSerializer).to receive(:new) { 'attributes' }
+      allow(ServiceProviderUpdater).to receive(:ping).and_call_original
       put :update, params: { id: sp.id, service_provider: { issuer: sp.issuer } }
+      provider = ServiceProvider.find_by(issuer: sp.issuer)
 
-      expect(Faraday).to have_received(:post).with(
-        IdentityConfig.store.idp_sp_url,
-        {service_provider: ServiceProviderSerializer.new(sp).to_json},
-        { 'X-LOGIN-DASHBOARD-TOKEN' => IdentityConfig.store.dashboard_api_token },
+      expect(ServiceProviderUpdater).to have_received(:ping).with(
+        { service_provider: 'attributes' },
       )
     end
   end

--- a/spec/controllers/service_providers_controller_spec.rb
+++ b/spec/controllers/service_providers_controller_spec.rb
@@ -163,7 +163,7 @@ describe ServiceProvidersController do
       expect(Faraday).to have_received(:post).with(
         IdentityConfig.store.idp_sp_url,
         {service_provider: ServiceProviderSerializer.new(sp).as_json},
-        { 'X-LOGIN-DASHBOARD-TOKEN' => IdentityConfig.store.dashboard_api_token }
+        { 'X-LOGIN-DASHBOARD-TOKEN' => IdentityConfig.store.dashboard_api_token },
       )
     end
   end

--- a/spec/controllers/service_providers_controller_spec.rb
+++ b/spec/controllers/service_providers_controller_spec.rb
@@ -155,5 +155,16 @@ describe ServiceProvidersController do
       put :update, params: { id: sp.id, service_provider: { issuer: sp.issuer, cert: empty_file } }
       expect(sp.reload.certs&.size).to equal(0)
     end
+
+    it 'sends a serialized service provider to the IDP' do
+      allow(Faraday).to receive(:post).and_call_original
+      put :update, params: { id: sp.id, service_provider: { issuer: sp.issuer } }
+
+      expect(Faraday).to have_received(:post).with(
+        IdentityConfig.store.idp_sp_url,
+        {service_provider: ServiceProviderSerializer.new(sp).as_json},
+        { 'X-LOGIN-DASHBOARD-TOKEN' => IdentityConfig.store.dashboard_api_token }
+      )
+    end
   end
 end

--- a/spec/services/service_provider_updater_spec.rb
+++ b/spec/services/service_provider_updater_spec.rb
@@ -22,7 +22,7 @@ describe ServiceProviderUpdater do
         expect(Faraday).to have_received(:post).with(
           IdentityConfig.store.idp_sp_url,
           nil,
-          { 'X-LOGIN-DASHBOARD-TOKEN' => IdentityConfig.store.dashboard_api_token }
+          { 'X-LOGIN-DASHBOARD-TOKEN' => IdentityConfig.store.dashboard_api_token },
         )
       end
     end
@@ -35,7 +35,7 @@ describe ServiceProviderUpdater do
         expect(Faraday).to have_received(:post).with(
           IdentityConfig.store.idp_sp_url,
           {service_provider: {}},
-          { 'X-LOGIN-DASHBOARD-TOKEN' => IdentityConfig.store.dashboard_api_token }
+          { 'X-LOGIN-DASHBOARD-TOKEN' => IdentityConfig.store.dashboard_api_token },
         )
       end
     end

--- a/spec/services/service_provider_updater_spec.rb
+++ b/spec/services/service_provider_updater_spec.rb
@@ -1,42 +1,35 @@
 require 'rails_helper'
 
 describe ServiceProviderUpdater do
+  let(:connection) { Faraday.new }
+  let(:url) { IdentityConfig.store.idp_sp_url }
+  let(:token) { IdentityConfig.store.dashboard_api_token }
   let(:status) { 200 }
+  let(:headers) do
+    {
+      'X-LOGIN-DASHBOARD-TOKEN' => token,
+      'Content-Type' => 'application/json'
+      }
+  end
 
   before do
-    stub_request(:post, IdentityConfig.store.idp_sp_url).
-      with(headers: { 'X-LOGIN-DASHBOARD-TOKEN' => IdentityConfig.store.dashboard_api_token }).
-      to_return(status: status)
+    stub_request(:post, url).
+      with(headers:).
+      to_return(status:)
   end
 
   describe '#ping' do
-    context 'when successful' do
+    context 'when a body is not passed through' do
       it 'returns status code 200 for success' do
         expect(ServiceProviderUpdater.ping).to eq 200
-      end
-
-      it 'does not pass a body through' do
-        allow(Faraday).to receive(:post).and_call_original
-        ServiceProviderUpdater.ping
-
-        expect(Faraday).to have_received(:post).with(
-          IdentityConfig.store.idp_sp_url,
-          nil,
-          { 'X-LOGIN-DASHBOARD-TOKEN' => IdentityConfig.store.dashboard_api_token },
-        )
       end
     end
 
     context 'when a body is passed in' do
-      it 'passes the body through the request' do
-        allow(Faraday).to receive(:post).and_call_original
-        ServiceProviderUpdater.ping({service_provider: {}})
+      let(:body) { {service_provider: {}} }
 
-        expect(Faraday).to have_received(:post).with(
-          IdentityConfig.store.idp_sp_url,
-          {service_provider: {}},
-          { 'X-LOGIN-DASHBOARD-TOKEN' => IdentityConfig.store.dashboard_api_token },
-        )
+      it 'returns status code 200 for success' do
+        expect(ServiceProviderUpdater.ping(body)).to eq 200
       end
     end
 

--- a/spec/services/service_provider_updater_spec.rb
+++ b/spec/services/service_provider_updater_spec.rb
@@ -14,6 +14,30 @@ describe ServiceProviderUpdater do
       it 'returns status code 200 for success' do
         expect(ServiceProviderUpdater.ping).to eq 200
       end
+
+      it 'does not pass a body through' do
+        allow(Faraday).to receive(:post).and_call_original
+        ServiceProviderUpdater.ping
+
+        expect(Faraday).to have_received(:post).with(
+          IdentityConfig.store.idp_sp_url,
+          nil,
+          { 'X-LOGIN-DASHBOARD-TOKEN' => IdentityConfig.store.dashboard_api_token }
+        )
+      end
+    end
+
+    context 'when a body is passed in' do
+      it 'passes the body through the request' do
+        allow(Faraday).to receive(:post).and_call_original
+        ServiceProviderUpdater.ping({service_provider: {}})
+
+        expect(Faraday).to have_received(:post).with(
+          IdentityConfig.store.idp_sp_url,
+          {service_provider: {}},
+          { 'X-LOGIN-DASHBOARD-TOKEN' => IdentityConfig.store.dashboard_api_token }
+        )
+      end
     end
 
     context 'when the HTTP request fails' do


### PR DESCRIPTION
### Relevant Ticket or Conversation:
https://cm-jira.usa.gov/browse/LG-10062

### Description of Changes:
This change updates the service_provider save code flow so that a single service provider is sent to the IDP to be synced in the sandbox, creating a much faster "publish." 

This change has a[ corresponding PR](https://github.com/18F/identity-idp/pull/9032) in the IDP that should be merged in first.

### PR Checklist:

1. [ ] Have you linted and tested your code locally prior to submission?
2. [ ] Have you tagged the appropriate dev(s) for review?
3. [ ] Have you linked to any relevant tickets or conversations?

### PR Review Standards: 
- Consider using [Conventional Comments](https://conventionalcomments.org/) to ensure that your feedback is clear and actionable.
- Ideally, PRs should be reviewed by at least 2 team members.
- All PRs must be approved before being merged. 
