### PR TITLE
Ensure that required label is present

### DIFF
--- a/app/javascript/packs/service_provider_form.js
+++ b/app/javascript/packs/service_provider_form.js
@@ -17,7 +17,7 @@ function ialOptionSetup() {
         hideElement(checkboxWrapper);
         checkboxInput.checked = false;
       }
-      failureToProofURLInput.required = false;
+      failureToProofURLInput.removeAttribute('required');
     });
   };
 
@@ -25,7 +25,7 @@ function ialOptionSetup() {
     ialAttributesCheckboxes.forEach((checkboxWrapper) => {
       showElement(checkboxWrapper);
     });
-    failureToProofURLInput.required = true;
+    failureToProofURLInput.setAttribute('required', 'required');
   };
 
   const toggleIALOptions = (ial) => {

--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -281,7 +281,7 @@ B7xxt8BVc69rHV15A0qyx77CLSj3tCx2IUXVqRs5mlvA==
                  label_html: { class: 'usa-input-required'},
                  label: 'Failure to Proof URL',
                  hint: I18n.t('service_provider_form.failure_to_proof_url'),
-                 required: form.object.ial == 2 ? true : false %>
+                 required: true %>
 
   <%= form.input :push_notification_url,
                  input_html: { class: 'usa-input' },


### PR DESCRIPTION
### Relevant Ticket or Conversation:
https://cm-jira.usa.gov/browse/LG-10585

### Description of Changes:
When running through acceptance steps, I noticed that the input was being marked as required and a user needed to include it to submit an IdV configuration, but the `*required` label was not being added initially. This solves that UX bug.

### PR Checklist:

1. [ ] Have you linted and tested your code locally prior to submission?
2. [ ] Have you tagged the appropriate dev(s) for review?
3. [ ] Have you linked to any relevant tickets or conversations?

### PR Review Standards: 
- Consider using [Conventional Comments](https://conventionalcomments.org/) to ensure that your feedback is clear and actionable.
- Ideally, PRs should be reviewed by at least 2 team members.
- All PRs must be approved before being merged. 
