### PR TITLE
Use static client_id (Reverting #688)

### DIFF
--- a/config/oidc.yml
+++ b/config/oidc.yml
@@ -1,5 +1,5 @@
 test: &default
-  client_id: "urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:dashboard<%= ':'+Identity::Hostdata.env if ['dev', 'int', 'ursula'].include?(Identity::Hostdata.env) %>"
+  client_id: urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:dashboard
   idp_url: http://localhost:3000
   dashboard_url: http://localhost:3001
 


### PR DESCRIPTION
### Relevant Ticket or Conversation:

Related to the discussion and changes in https://github.com/18F/identity-idp-config/pull/1928

### Description of Changes:

This PR reverts #688 so that the dashboard uses a static `client_id`

### PR Checklist:

1. [x] Have you linted and tested your code locally prior to submission?
2. [x] Have you tagged the appropriate dev(s) for review?
3. [x] Have you linked to any relevant tickets or conversations?

### PR Review Standards: 
- Consider using [Conventional Comments](https://conventionalcomments.org/) to ensure that your feedback is clear and actionable.
- Ideally, PRs should be reviewed by at least 2 team members.
- All PRs must be approved before being merged. 
