### PR TITLE
Fix failure to proof hint so the link displays as a link

### DIFF
--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -280,7 +280,7 @@ B7xxt8BVc69rHV15A0qyx77CLSj3tCx2IUXVqRs5mlvA==
                  input_html: { class: 'usa-input' },
                  label_html: { class: 'usa-input-required'},
                  label: 'Failure to Proof URL',
-                 hint: I18n.t('service_provider_form.failure_to_proof_url'),
+                 hint: I18n.t('service_provider_form.failure_to_proof_url').html_safe,
                  required: true %>
 
   <%= form.input :push_notification_url,


### PR DESCRIPTION
### Relevant Ticket or Conversation:

[LG-11452](https://cm-jira.usa.gov/browse/LG-11452)

### Description of Changes:

Fix the Failure to Proof hint so that the link is clickable, instead of printing out the HTML.

### PR Checklist:

1. [ ] Have you linted and tested your code locally prior to submission?
2. [ ] Have you tagged the appropriate dev(s) for review?
3. [ ] Have you linked to any relevant tickets or conversations?

### PR Review Standards: 
- Consider using [Conventional Comments](https://conventionalcomments.org/) to ensure that your feedback is clear and actionable.
- Ideally, PRs should be reviewed by at least 2 team members.
- All PRs must be approved before being merged. 
