### PR TITLE
Fix casing of database migration class names to match file names

### DIFF
--- a/db/migrate/20210401171237_move_saml_client_cert_to_certs.rb
+++ b/db/migrate/20210401171237_move_saml_client_cert_to_certs.rb
@@ -1,4 +1,4 @@
-class MoveSAMLClientCertToCerts < ActiveRecord::Migration[6.1]
+class MoveSamlClientCertToCerts < ActiveRecord::Migration[6.1]
   def up
     ActiveRecord::Base.connection.execute <<-SQL
       UPDATE service_providers

--- a/db/migrate/20210401225415_remove_service_providers_saml_client_cert.rb
+++ b/db/migrate/20210401225415_remove_service_providers_saml_client_cert.rb
@@ -1,4 +1,4 @@
-class RemoveServiceProvidersSAMLClientCert < ActiveRecord::Migration[6.1]
+class RemoveServiceProvidersSamlClientCert < ActiveRecord::Migration[6.1]
   def change
     remove_column :service_providers, :saml_client_cert, :string
   end


### PR DESCRIPTION
### Relevant Ticket or Conversation:

Slack discussion [here](https://gsa-tts.slack.com/archives/C01SU3NB9T3/p1704823624349349)

### Description of Changes:

This is a follow up to #707 to fix some class names that are being improperly inflected due to the casing of the class name.

### PR Checklist:

1. [x] Have you linted and tested your code locally prior to submission?
2. [x] Have you tagged the appropriate dev(s) for review?
3. [x] Have you linked to any relevant tickets or conversations?

### PR Review Standards: 
- Consider using [Conventional Comments](https://conventionalcomments.org/) to ensure that your feedback is clear and actionable.
- Ideally, PRs should be reviewed by at least 2 team members.
- All PRs must be approved before being merged. 
