### PR TITLE
Updating pull policy from IfNotPresent to Always to prevent stale images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -262,10 +262,13 @@ review-app:
       --debug
       --set idp.image.repository="${ECR_REGISTRY}/identity-idp/review"
       --set idp.image.tag="${IDP_IMAGE_TAG}"
+      --set idp.image.pullPolicy="Always"
       --set worker.image.repository="${ECR_REGISTRY}/identity-idp/review"
       --set worker.image.tag="${IDP_WORKER_IMAGE_TAG}"
+      --set worker.image.pullPolicy="Always"
       --set pivcac.image.repository="${ECR_REGISTRY}/identity-pivcac/review"
       --set pivcac.image.tag="${PKI_IMAGE_TAG}"
+      --set pivcac.image.pullPolicy="Always"
       --set dashboard.image.repository="${ECR_REGISTRY}/identity-dashboard/review"
       --set dashboard.image.tag="${CI_COMMIT_SHA}"
       --set-json dashboard.env="$DASHBOARD_ENV"


### PR DESCRIPTION
### Description of Changes:
Swaps from the default pull policy of `IfNotPresent` to `Always` for images that are referencing `main` to prevent stale containers from hanging around and being used.

### PR Checklist:

1. [x] Have you linted and tested your code locally prior to submission?
2. [ ] Have you tagged the appropriate dev(s) for review?
3. [ ] Have you linked to any relevant tickets or conversations?

### PR Review Standards: 
- Consider using [Conventional Comments](https://conventionalcomments.org/) to ensure that your feedback is clear and actionable.
- Ideally, PRs should be reviewed by at least 2 team members.
- All PRs must be approved before being merged. 
