### PR TITLE
Remove ability for users to edit help text

### DIFF
--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -354,28 +354,29 @@ B7xxt8BVc69rHV15A0qyx77CLSj3tCx2IUXVqRs5mlvA==
     <%= I18n.t('service_provider_form.active').html_safe %>
   </div>
 
-  <fieldset class="usa-fieldset-inputs custom-help-text">
-    <legend>Custom help text</legend>
-    <p>You can specify help text in these different areas to alert users of important information for logging into your app. Permitted HTML elements include the following:
-    <%= ServiceProvider::ALLOWED_HELP_TEXT_HTML_TAGS.map { |t| "<code>#{t}</code>" }.join(", ").html_safe %>.
-    </p>
-    <%= form.fields_for :help_text do |h| %>
-      <br><legend><b>Sign-in help text:</b></legend>
-      <%= h.input "sign_in[en]", label: "English", as: :text, required: false, input_html: { value: service_provider.help_text.dig("sign_in", "en") } %>
-      <%= h.input "sign_in[es]", label: "Español", as: :text, required: false, input_html: { value: service_provider.help_text.dig("sign_in", "es") } %>
-      <%= h.input "sign_in[fr]", label: "Français", as: :text, required: false, input_html: { value: service_provider.help_text.dig("sign_in", "fr") } %>
+  <% if current_user.admin? %>
+    <fieldset class="usa-fieldset-inputs custom-help-text">
+      <legend>Custom help text</legend>
+      <p>You can specify help text in these different areas to alert users of important information for logging into your app. Permitted HTML elements include the following:
+      <%= ServiceProvider::ALLOWED_HELP_TEXT_HTML_TAGS.map { |t| "<code>#{t}</code>" }.join(", ").html_safe %>.
+      </p>
+      <%= form.fields_for :help_text do |h| %>
+        <br><legend><b>Sign-in help text:</b></legend>
+        <%= h.input "sign_in[en]", label: "English", as: :text, required: false, input_html: { value: service_provider.help_text.dig("sign_in", "en") } %>
+        <%= h.input "sign_in[es]", label: "Español", as: :text, required: false, input_html: { value: service_provider.help_text.dig("sign_in", "es") } %>
+        <%= h.input "sign_in[fr]", label: "Français", as: :text, required: false, input_html: { value: service_provider.help_text.dig("sign_in", "fr") } %>
 
-      <br><legend><b>Sign-up help text:</b></legend>
-      <%= h.input "sign_up[en]", label: "English", as: :text, required: false, input_html: { value: service_provider.help_text.dig("sign_up", "en") } %>
-      <%= h.input "sign_up[es]", label: "Español", as: :text, required: false, input_html: { value: service_provider.help_text.dig("sign_up", "es") } %>
-      <%= h.input "sign_up[fr]", label: "Français", as: :text, required: false, input_html: { value: service_provider.help_text.dig("sign_up", "fr") } %>
+        <br><legend><b>Sign-up help text:</b></legend>
+        <%= h.input "sign_up[en]", label: "English", as: :text, required: false, input_html: { value: service_provider.help_text.dig("sign_up", "en") } %>
+        <%= h.input "sign_up[es]", label: "Español", as: :text, required: false, input_html: { value: service_provider.help_text.dig("sign_up", "es") } %>
+        <%= h.input "sign_up[fr]", label: "Français", as: :text, required: false, input_html: { value: service_provider.help_text.dig("sign_up", "fr") } %>
 
-      <br><legend><b>Forgot password help text:</b></legend>
-      <%= h.input  "forgot_password[en]", label: "English", as: :text, required: false, input_html: { value: service_provider.help_text.dig("forgot_password", "en") } %>
-      <%= h.input "forgot_password[es]", label: "Español", as: :text, required: false, input_html: { value: service_provider.help_text.dig("forgot_password", "es") } %>
-      <%= h.input "forgot_password[fr]", label: "Français", as: :text, required: false, input_html: { value: service_provider.help_text.dig("forgot_password", "fr") } %>
-    <% end %>
-  </fieldset>
-</fieldset>
+        <br><legend><b>Forgot password help text:</b></legend>
+        <%= h.input  "forgot_password[en]", label: "English", as: :text, required: false, input_html: { value: service_provider.help_text.dig("forgot_password", "en") } %>
+        <%= h.input "forgot_password[es]", label: "Español", as: :text, required: false, input_html: { value: service_provider.help_text.dig("forgot_password", "es") } %>
+        <%= h.input "forgot_password[fr]", label: "Français", as: :text, required: false, input_html: { value: service_provider.help_text.dig("forgot_password", "fr") } %>
+      <% end %>
+    </fieldset>
+  <% end %>
 
 <%= javascript_include_tag 'service_provider_form' %>


### PR DESCRIPTION
### Relevant Ticket or Conversation:

[LG-12042](https://cm-jira.usa.gov/browse/LG-12042)

### Description of Changes:

We no longer want users to be able to edit their own help text due to the frequency in which there are long disclaimers that push the actual form down and clutter the page /create a bad user experience

However we still want to allow admin users to edit the help text so this is now an admin only feature

### PR Checklist:

1. [ ] Have you linted and tested your code locally prior to submission?
2. [ ] Have you tagged the appropriate dev(s) for review?
3. [ ] Have you linked to any relevant tickets or conversations?

### PR Review Standards: 
- Consider using [Conventional Comments](https://conventionalcomments.org/) to ensure that your feedback is clear and actionable.
- Ideally, PRs should be reviewed by at least 2 team members.
- All PRs must be approved before being merged. 
