### PR TITLE
LG-12042  users can still see but not edit help text

### DIFF
--- a/app/controllers/service_providers_controller.rb
+++ b/app/controllers/service_providers_controller.rb
@@ -38,7 +38,9 @@ class ServiceProvidersController < AuthenticatedController
     @service_provider = ServiceProvider.new
   end
 
-  def edit; end
+  def edit
+    @help_text_empty = help_text_empty?
+  end
 
   def show; end
 
@@ -48,6 +50,12 @@ class ServiceProvidersController < AuthenticatedController
   end
 
   private
+
+  def help_text_empty?
+    service_provider.help_text["sign_in"].empty? &&
+    service_provider.help_text["sign_up"].empty? &&
+    service_provider.help_text["forgot_password"].empty?
+  end
 
   def service_provider
     @service_provider ||= ServiceProvider.find(params[:id])

--- a/app/controllers/service_providers_controller.rb
+++ b/app/controllers/service_providers_controller.rb
@@ -52,9 +52,9 @@ class ServiceProvidersController < AuthenticatedController
   private
 
   def help_text_empty?
-    service_provider.help_text["sign_in"].empty? &&
-    service_provider.help_text["sign_up"].empty? &&
-    service_provider.help_text["forgot_password"].empty?
+    service_provider.help_text['sign_in'].empty? &&
+      service_provider.help_text['sign_up'].empty? &&
+      service_provider.help_text['forgot_password'].empty?
   end
 
   def service_provider

--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -378,8 +378,26 @@ B7xxt8BVc69rHV15A0qyx77CLSj3tCx2IUXVqRs5mlvA==
       <% end %>
     </fieldset>
   <% else %>
-    <p class="usa-label">Help text</p>
-    <p>Do you need to edit the custom help text for your application? <a href="https://logingov.zendesk.com">Contact us</a>.</p>
+    <fieldset class="usa-fieldset-inputs custom-help-text">
+        <legend class="usa-label">Custom help text</legend>
+          <p>You can view your existing help text here.</p>
+          <p>Do you need to edit the custom help text for your application? <a href="https://logingov.zendesk.com">Contact us</a>.</p>
+          <legend class="usa-label"><b>Sign-in help text:</legend>
+          <div class="mb2 text optional"><label class="usa-label optional" for="english-sign-in">English</label><textarea id="english-sign-in" class="block col-12 text-normal optional" readonly><%= service_provider.help_text.dig("sign_in", "en") %></textarea></div>
+          <div class="mb2 text optional"><label class="usa-label optional" for="espanol-sign-in">Español</label><textarea id="espanol-sign-in" class="block col-12 text-normal optional" readonly><%= service_provider.help_text.dig("sign_in", "es") %></textarea></div>
+          <div class="mb2 text optional"><label class="usa-label optional" for="french-sign-in">Français</label><textarea id="french-sign-in" class="block col-12 text-normal optional" readonly><%= service_provider.help_text.dig("sign_in", "fr") %></textarea></div>
+
+          <legend class="usa-label"><b>Sign-up help text:</legend>
+          <div class="mb2 text optional"><label class="usa-label optional" for="english-sign-up">English</label><textarea id="english-sign-up" class="block col-12 text-normal optional" readonly><%= service_provider.help_text.dig("sign_up", "en") %></textarea></div>
+          <div class="mb2 text optional"><label class="usa-label optional" for="espanol-sign-up">Español</label><textarea id="espanol-sign-up" class="block col-12 text-normal optional" readonly><%= service_provider.help_text.dig("sign_up", "es") %></textarea></div>
+          <div class="mb2 text optional"><label class="usa-label optional" for="french-sign-up">Français</label><textarea id="french-sign-up" class="block col-12 text-normal optional" readonly><%= service_provider.help_text.dig("sign_up", "fr") %></textarea></div>
+
+          <legend class="usa-label">Forgot password help text:</legend>
+          <div class="mb2 text optional"><label class="usa-label optional" for="english-forgot-pass">English</label><textarea id="english-forgot-pass" class="block col-12 text-normal optional" readonly><%= service_provider.help_text.dig("forgot_password", "en") %></textarea></div>
+          <div class="mb2 text optional"><label class="usa-label optional" for="espanol-forgot-pass">Español</label><textarea id="espanol-forgot-pass" class="block col-12 text-normal optional" readonly><%= service_provider.help_text.dig("forgot_password", "es") %></textarea></div>
+          <div class="mb2 text optional"><label class="usa-label optional" for="french-forgot-pass">Français</label><textarea id="french-forgot-pass" class="block col-12 text-normal optional" readonly><%= service_provider.help_text.dig("forgot_password", "fr") %></textarea></div>
+    </fieldset>
+        
   <% end %>
 
 <%= javascript_include_tag 'service_provider_form' %>

--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -378,7 +378,12 @@ B7xxt8BVc69rHV15A0qyx77CLSj3tCx2IUXVqRs5mlvA==
       <% end %>
     </fieldset>
   <% else %>
-    <fieldset class="usa-fieldset-inputs custom-help-text">
+    <% if @help_text_empty %>
+      <p class="usa-label">Custom help text</p>
+      <p>You have no existing help text.</p>
+      <p>Do you need to add help text for your application? <a href="https://logingov.zendesk.com">Contact us</a>.</p>
+    <% else %>
+      <fieldset class="usa-fieldset-inputs custom-help-text">
         <legend class="usa-label">Custom help text</legend>
           <p>You can view your existing help text here.</p>
           <p>Do you need to edit the custom help text for your application? <a href="https://logingov.zendesk.com">Contact us</a>.</p>
@@ -396,8 +401,8 @@ B7xxt8BVc69rHV15A0qyx77CLSj3tCx2IUXVqRs5mlvA==
           <div class="mb2 text optional"><label class="usa-label optional" for="english-forgot-pass">English</label><textarea id="english-forgot-pass" class="block col-12 text-normal optional" readonly><%= service_provider.help_text.dig("forgot_password", "en") %></textarea></div>
           <div class="mb2 text optional"><label class="usa-label optional" for="espanol-forgot-pass">Español</label><textarea id="espanol-forgot-pass" class="block col-12 text-normal optional" readonly><%= service_provider.help_text.dig("forgot_password", "es") %></textarea></div>
           <div class="mb2 text optional"><label class="usa-label optional" for="french-forgot-pass">Français</label><textarea id="french-forgot-pass" class="block col-12 text-normal optional" readonly><%= service_provider.help_text.dig("forgot_password", "fr") %></textarea></div>
-    </fieldset>
-        
+      </fieldset>
+    <% end %>
   <% end %>
 
 <%= javascript_include_tag 'service_provider_form' %>


### PR DESCRIPTION
### Relevant Ticket or Conversation:

[LG-12042](https://cm-jira.usa.gov/browse/LG-12042)

### Description of Changes:

The last PR pertaining to this made it so users cannot see what their current help text looks like. This fixes it, giving them a read only view. 

### PR Checklist:

1. [x] Have you linted and tested your code locally prior to submission?
2. [x] Have you tagged the appropriate dev(s) for review?
3. [x] Have you linked to any relevant tickets or conversations?

### PR Review Standards: 
- Consider using [Conventional Comments](https://conventionalcomments.org/) to ensure that your feedback is clear and actionable.
- Ideally, PRs should be reviewed by at least 2 team members.
- All PRs must be approved before being merged. 
