### PR TITLE
Fix issue with frozen SMTP_SETTINGS

### DIFF
--- a/config/initializers/smtp.rb
+++ b/config/initializers/smtp.rb
@@ -6,7 +6,7 @@ SMTP_SETTINGS = {
   password: IdentityConfig.store.smtp_password,
   port: '587',
   user_name: IdentityConfig.store.smtp_username,
-}.freeze
+}
 
 if IdentityConfig.store.email_recipients.present?
   Mail.register_interceptor RecipientInterceptor.new(IdentityConfig.store.email_recipients)


### PR DESCRIPTION
### Relevant Ticket or Conversation:

[Slack conversation](https://gsa-tts.slack.com/archives/C16RSBG49/p1707257560908219)

### Description of Changes:

When booting in a deployed environment that uses a mailer configuration, the frozen hash is modified, which seems to be behavior that changed in Rails 7.1. This PR removes the `freeze` to fix it.

### PR Checklist:

1. [x] Have you linted and tested your code locally prior to submission?
2. [x] Have you tagged the appropriate dev(s) for review?
3. [x] Have you linked to any relevant tickets or conversations?

### PR Review Standards: 
- Consider using [Conventional Comments](https://conventionalcomments.org/) to ensure that your feedback is clear and actionable.
- Ideally, PRs should be reviewed by at least 2 team members.
- All PRs must be approved before being merged. 
