### PR TITLE
Updates help text form to correctly nest attributes

### DIFF
--- a/app/controllers/service_providers_controller.rb
+++ b/app/controllers/service_providers_controller.rb
@@ -53,9 +53,9 @@ class ServiceProvidersController < AuthenticatedController
   private
 
   def help_text_empty?
-    service_provider.help_text['sign_in'].empty? &&
-      service_provider.help_text['sign_up'].empty? &&
-      service_provider.help_text['forgot_password'].empty?
+    service_provider.help_text['sign_in'].blank? &&
+      service_provider.help_text['sign_up'].blank? &&
+      service_provider.help_text['forgot_password'].blank?
   end
 
   def service_provider

--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -361,21 +361,27 @@ B7xxt8BVc69rHV15A0qyx77CLSj3tCx2IUXVqRs5mlvA==
       <%= ServiceProvider::ALLOWED_HELP_TEXT_HTML_TAGS.map { |t| "<code>#{t}</code>" }.join(", ").html_safe %>.
       </p>
       <%= form.fields_for :help_text do |h| %>
-        <br><legend><b>Sign-in help text:</b></legend>
-        <%= h.input "sign_in[en]", label: "English", as: :text, required: false, input_html: { value: service_provider.help_text.dig("sign_in", "en") } %>
-        <%= h.input "sign_in[es]", label: "Español", as: :text, required: false, input_html: { value: service_provider.help_text.dig("sign_in", "es") } %>
-        <%= h.input "sign_in[fr]", label: "Français", as: :text, required: false, input_html: { value: service_provider.help_text.dig("sign_in", "fr") } %>
+        <%= h.fields_for :sign_in do |s| %>
+          <br><legend><b>Sign-in help text:</b></legend>
+          <%= s.input :en, label: "English", as: :text, required: false, input_html: { value: service_provider.help_text.dig("sign_in", "en") } %>
+          <%= s.input :es, label: "Español", as: :text, required: false, input_html: { value: service_provider.help_text.dig("sign_in", "es") } %>
+          <%= s.input :fr, label: "Français", as: :text, required: false, input_html: { value: service_provider.help_text.dig("sign_in", "fr") } %>
+        <% end %>
 
-        <br><legend><b>Sign-up help text:</b></legend>
-        <%= h.input "sign_up[en]", label: "English", as: :text, required: false, input_html: { value: service_provider.help_text.dig("sign_up", "en") } %>
-        <%= h.input "sign_up[es]", label: "Español", as: :text, required: false, input_html: { value: service_provider.help_text.dig("sign_up", "es") } %>
-        <%= h.input "sign_up[fr]", label: "Français", as: :text, required: false, input_html: { value: service_provider.help_text.dig("sign_up", "fr") } %>
+        <%= h.fields_for :sign_up do |s| %>
+          <br><legend><b>Sign-up help text:</b></legend>
+          <%= s.input :en, label: "English", as: :text, required: false, input_html: { value: service_provider.help_text.dig("sign_up", "en") } %>
+          <%= s.input :es, label: "Español", as: :text, required: false, input_html: { value: service_provider.help_text.dig("sign_up", "es") } %>
+          <%= s.input :fr, label: "Français", as: :text, required: false, input_html: { value: service_provider.help_text.dig("sign_up", "fr") } %>
+        <% end %>
 
-        <br><legend><b>Forgot password help text:</b></legend>
-        <%= h.input  "forgot_password[en]", label: "English", as: :text, required: false, input_html: { value: service_provider.help_text.dig("forgot_password", "en") } %>
-        <%= h.input "forgot_password[es]", label: "Español", as: :text, required: false, input_html: { value: service_provider.help_text.dig("forgot_password", "es") } %>
-        <%= h.input "forgot_password[fr]", label: "Français", as: :text, required: false, input_html: { value: service_provider.help_text.dig("forgot_password", "fr") } %>
-      <% end %>
+        <%= h.fields_for :forgot_password do |f| %>
+          <br><legend><b>Forgot password help text:</b></legend>
+          <%= f.input  :en, label: "English", as: :text, required: false, input_html: { value: service_provider.help_text.dig("forgot_password", "en") } %>
+          <%= f.input :es, label: "Español", as: :text, required: false, input_html: { value: service_provider.help_text.dig("forgot_password", "es") } %>
+          <%= f.input :fr, label: "Français", as: :text, required: false, input_html: { value: service_provider.help_text.dig("forgot_password", "fr") } %>
+        <% end %>
+    <% end %>
     </fieldset>
   <% else %>
     <% if @help_text_empty %>


### PR DESCRIPTION
### Relevant Ticket or Conversation:
https://cm-jira.usa.gov/browse/LG-12420

### Description of Changes:
This updates the help text inputs to be correctly formed.

https://github.com/18F/identity-dashboard/pull/728 broke the input fields. This happened because it updated sinatra, which updated the production rack version. The rack change included a [bug fix](https://github.com/rack/rack/blob/main/CHANGELOG.md#fixed-1) to [fix Utils.build_nested_query](https://github.com/rack/rack/pull/1989). (thanks andrew for finding the specific issue)
There was a bug in our form code that relied on THAT bug to work. This fixes that bug!

Before:
<img width="309" alt="Screenshot 2024-02-13 at 2 47 39 PM" src="https://github.com/18F/identity-dashboard/assets/5473830/f6248def-361c-401a-848a-bd89a70da4a2">

After:
<img width="256" alt="Screenshot 2024-02-13 at 2 48 23 PM" src="https://github.com/18F/identity-dashboard/assets/5473830/bf88dcc0-11e0-41bd-9024-ee26a4515708">


### PR Checklist:

1. [ ] Have you linted and tested your code locally prior to submission?
2. [ ] Have you tagged the appropriate dev(s) for review?
3. [ ] Have you linked to any relevant tickets or conversations?

### PR Review Standards: 
- Consider using [Conventional Comments](https://conventionalcomments.org/) to ensure that your feedback is clear and actionable.
- Ideally, PRs should be reviewed by at least 2 team members.
- All PRs must be approved before being merged. 
