### PR TITLE
Remove Security Events from non-admin users navigation #734

### DIFF
--- a/app/controllers/security_events_controller.rb
+++ b/app/controllers/security_events_controller.rb
@@ -7,6 +7,7 @@ class SecurityEventsController < ApplicationController
   end
 
   def index
+    render_401 unless current_user.admin?
     @security_events = current_user.security_events.
                        order('issued_at DESC').
                        page(params[:page])

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -103,11 +103,6 @@
               <li class="usa-nav__primary-item">
                 <%= link_to 'Teams', teams_path, class: 'usa-nav__link' %>
               </li>
-              <% if current_user.admin? %>
-                <li class="usa-nav__primary-item">
-                  <%= link_to 'Security Events', security_events_path, class: 'usa-nav__link' %>
-                </li>
-              <% end %>
               <li class="usa-nav__primary-item">
                 <button class="usa-accordion__button usa-nav__link" aria-controls="unique-id-tools-dropdown">
                   <span>Tools</span>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -103,10 +103,11 @@
               <li class="usa-nav__primary-item">
                 <%= link_to 'Teams', teams_path, class: 'usa-nav__link' %>
               </li>
-              <li class="usa-nav__primary-item">
-                <%= link_to 'Security Events', security_events_path, class: 'usa-nav__link' %>
-              </li>
-
+              <% if current_user.admin? %>
+                <li class="usa-nav__primary-item">
+                  <%= link_to 'Security Events', security_events_path, class: 'usa-nav__link' %>
+                </li>
+              <% end %>
               <li class="usa-nav__primary-item">
                 <button class="usa-accordion__button usa-nav__link" aria-controls="unique-id-tools-dropdown">
                   <span>Tools</span>

--- a/spec/controllers/security_events_controller_spec.rb
+++ b/spec/controllers/security_events_controller_spec.rb
@@ -14,6 +14,16 @@ RSpec.describe SecurityEventsController do
   end
 
   describe '#index' do
+    context 'user is not an admin' do
+      let(:user) { other_user }
+      it 'renders unauthorized' do
+        get :index
+        expect(user.admin).to be false
+        expect(response).to be_unauthorized
+      end
+    end
+
+    let(:user) { create(:admin) }
     it 'renders security events for the current user only' do
       get :index
 


### PR DESCRIPTION
### Relevant Ticket or Conversation:

[LG-11789](https://cm-jira.usa.gov/browse/LG-11789)

### Description of Changes:

Removes `Security Events` from the navigation. For non-admin users who have the URL saved, they'll receive a `401 Unauthorized` response.

This PR completely removes the Security Events link from the navigation for all users, not just for non-admins.

### PR Checklist:

1. [X] Have you linted and tested your code locally prior to submission?
2. [X] Have you tagged the appropriate dev(s) for review?
3. [X] Have you linked to any relevant tickets or conversations?

### PR Review Standards: 
- Consider using [Conventional Comments](https://conventionalcomments.org/) to ensure that your feedback is clear and actionable.
- Ideally, PRs should be reviewed by at least 2 team members.
- All PRs must be approved before being merged. 
