### PR TITLE
Move Update action from API controller

### DIFF
--- a/app/controllers/api/service_providers_controller.rb
+++ b/app/controllers/api/service_providers_controller.rb
@@ -1,6 +1,5 @@
 module Api
   class ServiceProvidersController < ApplicationController
-    before_action(:authenticate_user!, only: [:update])
 
     def index
       render json: serialized_service_providers(approved_service_providers)
@@ -8,15 +7,6 @@ module Api
 
     def show
       render json: ServiceProviderSerializer.new(service_provider, action: :show).as_json
-    end
-
-    def update
-      if ServiceProviderUpdater.post_update == 200
-        flash[:notice] = I18n.t('notices.service_providers_refreshed')
-      else
-        flash[:error] = I18n.t('notices.service_providers_refresh_failed')
-      end
-      redirect_to service_providers_path
     end
 
     private

--- a/app/controllers/service_providers_controller.rb
+++ b/app/controllers/service_providers_controller.rb
@@ -80,6 +80,16 @@ class ServiceProvidersController < AuthenticatedController
     ]
   end
 
+  def publish
+    if ServiceProviderUpdater.post_update == 200
+      flash[:notice] = I18n.t('notices.service_providers_refreshed')
+    else
+      flash[:error] = I18n.t('notices.service_providers_refresh_failed')
+    end
+    redirect_to service_providers_path
+  end
+
+
   private
 
   def help_text_empty?

--- a/app/views/service_providers/all.html.erb
+++ b/app/views/service_providers/all.html.erb
@@ -1,3 +1,3 @@
-<%= button_to t('forms.buttons.trigger_idp_refresh'), api_service_providers_path, method: :post, :class => "usa-button" %>
+<%= button_to t('forms.buttons.trigger_idp_refresh'), service_providers_publish_path, method: :post, :class => "usa-button" %>
 
 <%= render partial: 'service_provider_table', locals: { service_providers: @service_providers, show_created_at: true } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,6 @@ Rails.application.routes.draw do
   post '/api/security_events' => 'api/security_events#create'
   get '/api/service_providers' => 'api/service_providers#index'
   get '/api/service_providers/:id' => 'api/service_providers#show'
-  post '/api/service_providers' => 'api/service_providers#update'
 
   root to: 'home#index'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
 
   get '/emails' => 'emails#index'
   get '/service_providers/all' => 'service_providers#all'
+  post '/service_providers/publish' => 'service_providers#publish'
   resources :service_providers
 
   get '/security_events/all' => 'security_events#all'

--- a/spec/controllers/api/service_providers_controller_spec.rb
+++ b/spec/controllers/api/service_providers_controller_spec.rb
@@ -56,46 +56,4 @@ describe Api::ServiceProvidersController do
     end
 
   end
-
-  describe '#update' do
-    context 'no user' do
-      it 'requires authentication' do
-        post :update
-
-        expect(response).to redirect_to root_url
-      end
-    end
-
-    context 'with user' do
-      before do
-        user = create(:user)
-        sign_in(user)
-      end
-
-      it 'redirects to service_providers_path' do
-        post :update
-
-        expect(response).to redirect_to service_providers_path
-      end
-
-      context 'when ServiceProviderUpdater fails' do
-        before do
-          stub_request(:post, IdentityConfig.store.idp_sp_url).
-            to_return(status: 404)
-        end
-
-        it 'redirects to service_providers_path' do
-          post :update
-
-          expect(response).to redirect_to service_providers_path
-        end
-
-        it 'notifies NewRelic of the error' do
-          expect(::NewRelic::Agent).to receive(:notice_error)
-
-          post :update
-        end
-      end
-    end
-  end
 end

--- a/spec/controllers/service_providers_controller_spec.rb
+++ b/spec/controllers/service_providers_controller_spec.rb
@@ -167,4 +167,46 @@ describe ServiceProvidersController do
       )
     end
   end
+
+  describe '#publish' do
+    context 'no user' do
+      it 'requires authentication' do
+        post :publish
+
+        expect(response).to redirect_to root_url
+      end
+    end
+
+    context 'with user' do
+      before do
+        user = create(:user)
+        sign_in(user)
+      end
+
+      it 'redirects to service_providers_path' do
+        post :publish
+
+        expect(response).to redirect_to service_providers_path
+      end
+
+      context 'when ServiceProviderUpdater fails' do
+        before do
+          stub_request(:post, IdentityConfig.store.idp_sp_url).
+            to_return(status: 404)
+        end
+
+        it 'redirects to service_providers_path' do
+          post :publish
+
+          expect(response).to redirect_to service_providers_path
+        end
+
+        it 'notifies NewRelic of the error' do
+          expect(::NewRelic::Agent).to receive(:notice_error)
+
+          post :publish
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Relevant Ticket or Conversation:

[LG-10946](https://cm-jira.usa.gov/browse/LG-10946)

### Description of Changes:

The `Api/ServiceProviderController#update` method was called by a user button press on the front end. This feels like not the best place for this method, this PR moves it to the `ServiceProviderController` and renames it to `publish` as the action is completes is re-publishing the SPs in the int environment.

### PR Checklist:

1. [ ] Have you linted and tested your code locally prior to submission?
2. [ ] Have you tagged the appropriate dev(s) for review?
3. [ ] Have you linked to any relevant tickets or conversations?

### PR Review Standards: 
- Consider using [Conventional Comments](https://conventionalcomments.org/) to ensure that your feedback is clear and actionable.
- Ideally, PRs should be reviewed by at least 2 team members.
- All PRs must be approved before being merged. 
