### PR TITLE
Add flex display to buttons

### DIFF
--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -2,14 +2,18 @@
 <h1 class="usa-display">Users</h1>
 
 <table class="usa-table">
-  <div>
-    <%= button_to t('headings.users.new_user'), new_user_path,
-                  method: :get, :class => "usa-button" %>
+  <div class="display-flex">
+    <%= button_to t('headings.users.new_user'),
+      new_user_path,
+      method: :get,
+      class: 'usa-button'
+    %>
 
     <% if can_delete_unconfirmed_users?(current_user, @users) %>
       <%= button_to t('forms.buttons.remove_unconfirmed_users'),
-                    remove_unconfirmed_users_path,
-                    method: :delete, :class => "usa-button" %>
+        remove_unconfirmed_users_path,
+        method: :delete,
+        class: 'usa-button' %>
     <% end %>
   </div>
   <thead>


### PR DESCRIPTION
### Relevant Ticket or Conversation:
I noticed a small UX bug on the users/index view after the design update. 

### Description of Changes:
Before:
<img width="622" alt="Two buttons ('Create a new user' and 'Remove unconfirmed user') are stacked and smushed next to each other" src="https://github.com/18F/identity-dashboard/assets/5473830/bc2d7cee-59b8-4700-81b5-b014c4016496">

After:
<img width="649" alt="wo buttons ('Create a new user' and 'Remove unconfirmed user') are side-by-side with appopriate padding between them)" src="https://github.com/18F/identity-dashboard/assets/5473830/196f807a-f14e-46e3-9783-477b6cf127f3">

### PR Checklist:

1. [ ] Have you linted and tested your code locally prior to submission?
2. [ ] Have you tagged the appropriate dev(s) for review?
3. [ ] Have you linked to any relevant tickets or conversations?

### PR Review Standards: 
- Consider using [Conventional Comments](https://conventionalcomments.org/) to ensure that your feedback is clear and actionable.
- Ideally, PRs should be reviewed by at least 2 team members.
- All PRs must be approved before being merged. 
