### PR TITLE
Resize Icons on Env Dashbord

### DIFF
--- a/app/views/env/index.html.erb
+++ b/app/views/env/index.html.erb
@@ -20,15 +20,15 @@
     <div>
       <% if status.status_class == 'deploy-success' %>
 
-        <%= image_tag 'alerts/success.svg', alt: 'success', height: '27', width: '27', :class =>'margin-bottom-neg-105', role: 'img' %>
+        <%= image_tag 'alerts/success.svg', alt: 'success', height: '16', width: '16', :class =>'margin-bottom-neg-05', role: 'img' %>
 
       <% elsif status.status_class == 'deploy-error' %>
 
-        <%= image_tag 'alerts/error.svg', alt: 'error', height: '27', width: '27', :class =>'margin-bottom-neg-1', role: 'img' %>
+        <%= image_tag 'alerts/error.svg', alt: 'error', height: '16', width: '16', :class =>'margin-bottom-neg-05', role: 'img' %>
 
       <% elsif status.status_class == 'disabled' %>
 
-       <%= image_tag 'alerts/warning.svg', alt: 'disabled', height: '27', width: '27',  :class =>'margin-bottom-neg-105', role: img %>
+       <%= image_tag 'alerts/warning.svg', alt: 'disabled', height: '16', width: '16',  :class =>'margin-bottom-neg-05', role: img %>
       <% end %>
 
       <% if status.host %>


### PR DESCRIPTION
### Relevant Ticket or Conversation:
I noticed earlier today that our environments dashboard is showing large icons after changes in the design system [[1](https://github.com/18F/identity-dashboard/pull/748), [2](https://github.com/18F/identity-dashboard/pull/750)].

https://dashboard.dev.identitysandbox.gov/env

**Before this PR**
<img width="903" alt="before" src="https://github.com/18F/identity-dashboard/assets/6818839/1e391442-2ebc-45e2-9b8e-e9dd40d1269b">

**After this PR**
![after](https://github.com/18F/identity-dashboard/assets/6818839/adbb5f87-dfc5-484e-be25-0f8c97274e90)


### Description of Changes:
This PR resizes the icons on the dashboard page here: https://dashboard.dev.identitysandbox.gov/env.

Note: Searching for `image_tag` across this repo shows me other potential icon size problems in `app/views/service_providers/_service_provider_table_row.erb` and `app/views/users/index.html.erb`, but I can't easily get to those pages locally so I'm deferring that for now.

### PR Checklist:

1. [x] Have you linted and tested your code locally prior to submission?
    - [x] Successful `make lint`
    - [x] Successful `make test` (6 pending tests, but I doubt that's related to this PR)
3. [x] Have you tagged the appropriate dev(s) for review?
    - [x] Andrew Duthie tagged for review
5. [x] Have you linked to any relevant tickets or conversations?
    - [x] Yes, but it's minimal.

### PR Review Standards: 
- Consider using [Conventional Comments](https://conventionalcomments.org/) to ensure that your feedback is clear and actionable.
- Ideally, PRs should be reviewed by at least 2 team members.
- All PRs must be approved before being merged. 
