### PR TITLE
LG-13064 HTML parsing bug

### DIFF
--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -20,13 +20,13 @@
                  input_html: { class: 'usa-input' },
                  label_html: { class: 'usa-input-required'},
                  label: 'App name',
-                 hint: I18n.t('service_provider_form.app_name_html') %>
+                 hint: t('service_provider_form.app_name_html') %>
 
   <%= form.input :friendly_name,
                  input_html: { class: 'usa-input', aria: { invalid: false } },
                  label_html: { class: 'usa-input-required'},
                  label: 'Friendly name',
-                 hint: I18n.t('service_provider_form.friendly_name_html') %>
+                 hint: t('service_provider_form.friendly_name_html') %>
 
 
   <%= form.input :description,
@@ -71,7 +71,7 @@
                  selected: form.object.ial,
                  input_html: { class: 'usa-input usa-select'},
                  label: 'Level of Service',
-                 hint: I18n.t('service_provider_form.identity_assurance_level_html') %>
+                 hint: t('service_provider_form.identity_assurance_level_html') %>
 
   <%= form.input :default_aal,
                  as: :select,
@@ -90,7 +90,7 @@
     <%= form.label :attribute_bundle,
                    label: 'Attribute bundle',
                    class: 'usa-label' %>
-    <%= form.hint I18n.t('service_provider_form.attribute_bundle_html') %>
+    <%= form.hint t('service_provider_form.attribute_bundle_html') %>
 
     <span class="usa-error-message js-bundle-input-error-message">
       <%= service_provider.errors[:attribute_bundle].to_sentence.presence %>
@@ -114,7 +114,7 @@
                  hint: if form.object.persisted?
                      I18n.t('service_provider_form.change_issuer')
                    else
-                     I18n.t('service_provider_form.issuer_html')
+                     t('service_provider_form.issuer_html')
                    end %>
 
   <% if current_user.admin? %>
@@ -155,7 +155,7 @@
                    placeholder: 'generic.svg',
                    label: 'Logo',
                    input_html: { class: 'usa-input' },
-                   hint: I18n.t('service_provider_form.logo_html') %>
+                   hint: t('service_provider_form.logo_html') %>
   <% end %>
 
   <fieldset class="usa-fieldset" id="certificate-container">
@@ -227,17 +227,17 @@ B7xxt8BVc69rHV15A0qyx77CLSj3tCx2IUXVqRs5mlvA==
                    label_html: { class: 'usa-input-required'},
                    label: 'Assertion Consumer Service URL',
                    required: true,
-                   hint: I18n.t('service_provider_form.assertion_consumer_service_url_html') %>
+                   hint: t('service_provider_form.assertion_consumer_service_url_html') %>
 
     <%= form.input :assertion_consumer_logout_service_url,
                    input_html: { class: 'usa-input' },
                    label: 'Assertion Consumer Logout Service URL',
-                   hint: I18n.t('service_provider_form.assertion_consumer_logout_service_url_html') %>
+                   hint: t('service_provider_form.assertion_consumer_logout_service_url_html') %>
 
     <%= form.input :sp_initiated_login_url,
                    input_html: { class: 'usa-input' },
                    label: 'SP Initiated Login URL',
-                   hint: I18n.t('service_provider_form.sp_initiated_login_url_html') %>
+                   hint: t('service_provider_form.sp_initiated_login_url_html') %>
 
     <%= form.input :block_encryption,
                    input_html: { class: 'usa-select' },
@@ -266,7 +266,7 @@ B7xxt8BVc69rHV15A0qyx77CLSj3tCx2IUXVqRs5mlvA==
                   label_html: { class: 'usa-input-required'},
                   label: 'Return to App URL',
                   required: true,
-                  hint: I18n.t('service_provider_form.return_to_app_url_html') %>
+                  hint: t('service_provider_form.return_to_app_url_html') %>
   </div>
   <%= form.input :failure_to_proof_url,
                  input_html: { class: 'usa-input', aria: { invalid: false } },
@@ -314,11 +314,11 @@ B7xxt8BVc69rHV15A0qyx77CLSj3tCx2IUXVqRs5mlvA==
     <% end %>
 
     <div class='oidc-fields'>
-      <%= I18n.t('service_provider_form.oidc_redirects_html') %>
+      <%= t('service_provider_form.oidc_redirects_html') %>
     </div>
 
     <div class='saml-fields margin-0'>
-      <%= form.hint I18n.t('service_provider_form.saml_redirects_html') %>
+      <%= form.hint t('service_provider_form.saml_redirects_html') %>
     </div>
 
     <%= form.button :button,

--- a/app/views/service_providers/show.html.erb
+++ b/app/views/service_providers/show.html.erb
@@ -12,14 +12,14 @@
   <label for="name">App name: </label>
   <span class="font-mono-xs margin-left-5"><%= service_provider.app_name %></span>
 </h2>
-<p class="text-italic"><%= I18n.t('service_provider_form.app_name_html') %></p>
+<p class="text-italic"><%= t('service_provider_form.app_name_html') %></p>
 <hr>
 
 <h2 class="margin-bottom-0">
   <label for="name">Friendly name:</label>
   <span class="font-mono-xs margin-left-5"><%= service_provider.friendly_name %></span>
 </h2>
-<p class="text-italic"><%= I18n.t('service_provider_form.friendly_name_html') %></p>
+<p class="text-italic"><%= t('service_provider_form.friendly_name_html') %></p>
 <hr>
 
 <h2 class="margin-bottom-0">
@@ -55,7 +55,7 @@
   <label for="ial_friendly">Level of Service:</label>
   <span class="font-mono-xs margin-left-5"><%= service_provider.ial_friendly %></span>
 </h2>
-<div class="text-italic"><%= I18n.t('service_provider_form.identity_assurance_level_html') %></div>
+<div class="text-italic"><%= t('service_provider_form.identity_assurance_level_html') %></div>
 <hr>
 
 <h2 class="margin-bottom-0">
@@ -69,7 +69,7 @@
   <span class="font-mono-xs margin-left-5"><%= service_provider.issuer %></span>
 </h2>
 <p class="text-italic"><%= I18n.t('service_provider_form.change_issuer') %></p>
-<div class="text-italic"><%= I18n.t('service_provider_form.issuer_html') %></div>
+<div class="text-italic"><%= t('service_provider_form.issuer_html') %></div>
 <hr>
 
 <% if current_user.admin? %>
@@ -101,7 +101,7 @@
   <% end %>
 <% else %>
   <h2 class="margin-bottom-0"><label for="logo">Logo:</label></h2>
-  <p class="text-italic"><%= I18n.t('service_provider_form.logo_html') %></p>
+  <p class="text-italic"><%= t('service_provider_form.logo_html') %></p>
   <% if service_provider.logo %>
   <p class="font-mono-xs margin-top-0 margin-left-5" name="logo">
     <a href="https://github.com/18F/identity-idp/tree/main/app/assets/images/sp-logos/<%= service_provider.logo %>" class="usa-link">
@@ -117,21 +117,21 @@
     <label for="acs_url">Assertion Consumer Service URL:</label>
     <span class="font-mono-xs margin-left-5"><%= service_provider.acs_url %></span>
   </h2>
-  <p class="text-italic"><%= I18n.t('service_provider_form.assertion_consumer_service_url_html') %></p>
+  <p class="text-italic"><%= t('service_provider_form.assertion_consumer_service_url_html') %></p>
   <hr>
 
   <h2 class="margin-bottom-0">
     <label for="assertion_consumer_logout_service_url">Assertion Consumer Logout Service URL:</label>
     <span class="font-mono-xs margin-left-5"><%= service_provider.assertion_consumer_logout_service_url %></span>
   </h2>
-  <p class="text-italic"><%= I18n.t('service_provider_form.assertion_consumer_logout_service_url_html') %></p>
+  <p class="text-italic"><%= t('service_provider_form.assertion_consumer_logout_service_url_html') %></p>
   <hr>
 
   <h2 class="margin-bottom-0">
     <label for="assertion_consumer_logout_service_url">SP Initiated Login URL:</label>
     <span class="font-mono-xs margin-left-5"><%= service_provider.sp_initiated_login_url %></span>
   </h2>
-  <p class="text-italic"><%= I18n.t('service_provider_form.sp_initiated_login_url_html') %></p>
+  <p class="text-italic"><%= t('service_provider_form.sp_initiated_login_url_html') %></p>
   <hr>
 
   <h2 class="margin-bottom-0">
@@ -152,7 +152,7 @@
     <label for="return_to_sp_url">Return to App URL: </label>
     <span class="font-mono-xs margin-left-5"><%= service_provider.return_to_sp_url %></span>
   </h2>
-  <p class="text-italic"><%= I18n.t('service_provider_form.return_to_app_url_html') %></p>
+  <p class="text-italic"><%= t('service_provider_form.return_to_app_url_html') %></p>
   <hr>
 <% end %>
 
@@ -182,11 +182,11 @@
 
 <% if service_provider.oidc? %>
   <h2 class="margin-bottom-0"><label for="uris">Redirect URIs:</label></h2>
-  <p class="text-italic"><%= I18n.t('service_provider_form.oidc_redirects_html') %></p>
+  <p class="text-italic"><%= t('service_provider_form.oidc_redirects_html') %></p>
   <p class="font-mono-xs margin-top-0 margin-left-5" name="uris"><%= (service_provider.redirect_uris || []).sort.join('<br>').html_safe %></p>
 <% else # SAML %>
   <h2><label for="uris">Additional Redirect URIs:</label></h2>
-  <p class="text-italic"><%= I18n.t('service_provider_form.saml_redirects_html') %></p>
+  <p class="text-italic"><%= t('service_provider_form.saml_redirects_html') %></p>
   <p class="font-mono-xs margin-top-0 margin-left-5" name="uris"><%= (service_provider.redirect_uris || []).sort.join('<br>').html_safe %></p>
 <% end %>
 <hr>
@@ -195,7 +195,7 @@
   <label for="attribute_bundle">Attribute bundle:</label>
   <span class="font-mono-xs margin-left-5"><%= sp_attribute_bundle(service_provider) %></span>
 </h2>
-<p class="text-italic"><%= I18n.t('service_provider_form.attribute_bundle_html') %></p>
+<p class="text-italic"><%= t('service_provider_form.attribute_bundle_html') %></p>
 <hr>
 
 <h2 class="margin-bottom-0">

--- a/config/locales/service_providers.en.yml
+++ b/config/locales/service_providers.en.yml
@@ -1,8 +1,8 @@
 ---
 en:
   service_provider_form:
-    app_name_html: "The name of your application <span class='text-heavy'>as it appears in the signed Inter-Agency Agreement (IAA)</span> with Login.gov. Ex: DHS - CSP"
-    friendly_name_html: "The name of your app that will be <span class='text-heavy'>displayed to users</span> when logging in. Example: DHS Customer Service Portal"
+    app_name_html: "The name of your application <span class='text-bold'>as it appears in the signed Inter-Agency Agreement (IAA)</span> with Login.gov. Ex: DHS - CSP"
+    friendly_name_html: "The name of your app that will be <span class='text-bold'>displayed to users</span> when logging in. Example: DHS Customer Service Portal"
     description: "A description of the app (may be helpful for your colleagues)."
     team: "Assign an agency team to this client."
     protocol: "This is the authentication protocol used by the service provider. We highly recommend using OpenID Connect, unless a technical reason prevents you."

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@18f/identity-build-sass": "^3.0.0",
+    "@18f/identity-design-system": "9.0.0",
     "@babel/core": "^7.23.2",
     "@babel/preset-env": "^7.23.2",
     "@rails/ujs": "^6.1.6",
@@ -18,7 +19,6 @@
     "babel-plugin-polyfill-corejs3": "^0.8.0",
     "core-js": "^3.23.4",
     "fast-glob": "^3.2.11",
-    "@18f/identity-design-system": "9.0.0",
     "webpack": "^5.90.3",
     "webpack-cli": "^5.1.4"
   },

--- a/spec/features/service_providers_spec.rb
+++ b/spec/features/service_providers_spec.rb
@@ -1,4 +1,7 @@
 require 'rails_helper'
+def StripTags(str)
+  ActionController::Base.helpers.strip_tags(str)
+end
 
 feature 'Service Providers CRUD' do
   before do
@@ -50,7 +53,7 @@ feature 'Service Providers CRUD' do
 
       visit service_provider_path(service_provider)
 
-      expect(page).to have_content(I18n.t('service_provider_form.saml_redirects_html'))
+      expect(page).to have_content(StripTags(t('service_provider_form.saml_redirects_html')))
       expect(page).to have_content(I18n.t('service_provider_form.saml_assertion_encryption'))
     end
 
@@ -61,7 +64,7 @@ feature 'Service Providers CRUD' do
 
       visit service_provider_path(service_provider)
 
-      expect(page).to have_content(I18n.t('service_provider_form.oidc_redirects_html'))
+      expect(page).to have_content(StripTags(t('service_provider_form.oidc_redirects_html')))
     end
 
     scenario 'saml fields are shown on sp edit page when saml is selected' do
@@ -71,11 +74,11 @@ feature 'Service Providers CRUD' do
 
       visit edit_service_provider_path(service_provider)
 
-      expect(page).to have_content(I18n.t('service_provider_form.saml_redirects_html'))
+      expect(page).to have_content(StripTags(t('service_provider_form.saml_redirects_html')))
       expect(page).to have_content(I18n.t('service_provider_form.saml_assertion_encryption'))
       # rubocop:disable Layout/LineLength
-      expect(page).to have_content(I18n.t('service_provider_form.assertion_consumer_service_url_html'))
-      expect(page).to have_content(I18n.t('service_provider_form.assertion_consumer_logout_service_url_html'))
+      expect(page).to have_content(StripTags(t('service_provider_form.assertion_consumer_service_url_html')))
+      expect(page).to have_content(StripTags(t('service_provider_form.assertion_consumer_logout_service_url_html')))
       # rubocop:enable Layout/LineLength
     end
 
@@ -86,7 +89,7 @@ feature 'Service Providers CRUD' do
 
       visit edit_service_provider_path(service_provider)
 
-      expect(page).to have_content(I18n.t('service_provider_form.oidc_redirects_html'))
+      expect(page).to have_content(StripTags(t('service_provider_form.oidc_redirects_html')))
     end
 
     scenario 'can update service provider team', :js do
@@ -291,7 +294,7 @@ feature 'Service Providers CRUD' do
         expect(page).to_not have_content(t("simple_form.labels.service_provider.#{atr}"))
       end
 
-      expect(page).to have_content(t('service_provider_form.oidc_redirects_html'))
+      expect(page).to have_content(StripTags(t('service_provider_form.oidc_redirects_html')))
     end
 
     scenario 'IAL1 attributes shown when IAL1 is selected', :js do

--- a/spec/features/service_providers_spec.rb
+++ b/spec/features/service_providers_spec.rb
@@ -1,11 +1,12 @@
 require 'rails_helper'
-def StripTags(str)
-  ActionController::Base.helpers.strip_tags(str)
-end
 
 feature 'Service Providers CRUD' do
   before do
     allow(IdentityConfig.store).to receive(:logo_upload_enabled).and_return(false)
+  end
+
+  def strip_tags(str)
+    ActionController::Base.helpers.strip_tags(str)
   end
 
   context 'Regular user' do
@@ -53,7 +54,7 @@ feature 'Service Providers CRUD' do
 
       visit service_provider_path(service_provider)
 
-      expect(page).to have_content(StripTags(t('service_provider_form.saml_redirects_html')))
+      expect(page).to have_content(strip_tags(t('service_provider_form.saml_redirects_html')))
       expect(page).to have_content(I18n.t('service_provider_form.saml_assertion_encryption'))
     end
 
@@ -64,7 +65,7 @@ feature 'Service Providers CRUD' do
 
       visit service_provider_path(service_provider)
 
-      expect(page).to have_content(StripTags(t('service_provider_form.oidc_redirects_html')))
+      expect(page).to have_content(strip_tags(t('service_provider_form.oidc_redirects_html')))
     end
 
     scenario 'saml fields are shown on sp edit page when saml is selected' do
@@ -74,11 +75,11 @@ feature 'Service Providers CRUD' do
 
       visit edit_service_provider_path(service_provider)
 
-      expect(page).to have_content(StripTags(t('service_provider_form.saml_redirects_html')))
+      expect(page).to have_content(strip_tags(t('service_provider_form.saml_redirects_html')))
       expect(page).to have_content(I18n.t('service_provider_form.saml_assertion_encryption'))
       # rubocop:disable Layout/LineLength
-      expect(page).to have_content(StripTags(t('service_provider_form.assertion_consumer_service_url_html')))
-      expect(page).to have_content(StripTags(t('service_provider_form.assertion_consumer_logout_service_url_html')))
+      expect(page).to have_content(strip_tags(t('service_provider_form.assertion_consumer_service_url_html')))
+      expect(page).to have_content(strip_tags(t('service_provider_form.assertion_consumer_logout_service_url_html')))
       # rubocop:enable Layout/LineLength
     end
 
@@ -89,7 +90,7 @@ feature 'Service Providers CRUD' do
 
       visit edit_service_provider_path(service_provider)
 
-      expect(page).to have_content(StripTags(t('service_provider_form.oidc_redirects_html')))
+      expect(page).to have_content(strip_tags(t('service_provider_form.oidc_redirects_html')))
     end
 
     scenario 'can update service provider team', :js do
@@ -294,7 +295,7 @@ feature 'Service Providers CRUD' do
         expect(page).to_not have_content(t("simple_form.labels.service_provider.#{atr}"))
       end
 
-      expect(page).to have_content(StripTags(t('service_provider_form.oidc_redirects_html')))
+      expect(page).to have_content(strip_tags(t('service_provider_form.oidc_redirects_html')))
     end
 
     scenario 'IAL1 attributes shown when IAL1 is selected', :js do

--- a/yarn.lock
+++ b/yarn.lock
@@ -1816,15 +1816,10 @@ camelcase@^6.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
-caniuse-lite@^1.0.30001503, caniuse-lite@^1.0.30001541:
-  version "1.0.30001549"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001549.tgz"
-  integrity sha512-qRp48dPYSCYaP+KurZLhDYdVE+yEyht/3NlmcJgVQ2VMGt6JL36ndQ/7rgspdZsJuxDPFIo/OzBT2+GmIJ53BA==
-
-caniuse-lite@^1.0.30001587:
-  version "1.0.30001589"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001589.tgz#7ad6dba4c9bf6561aec8291976402339dc157dfb"
-  integrity sha512-vNQWS6kI+q6sBlHbh71IIeC+sRwK2N3EDySc/updIGhIee2x5z00J4c1242/5/d6EpEMdOnk/m+6tuk4/tcsqg==
+caniuse-lite@^1.0.30001503, caniuse-lite@^1.0.30001541, caniuse-lite@^1.0.30001587:
+  version "1.0.30001610"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001610.tgz"
+  integrity sha512-QFutAY4NgaelojVMjY63o6XlZyORPaLfyMnsl3HgnWdJUcX6K0oaJymHjH8PT5Gk7sTm8rvC/c5COUQKXqmOMA==
 
 chai@^4.3.10:
   version "4.3.10"


### PR DESCRIPTION
### Relevant Ticket or Conversation:
[LG-13064](https://cm-jira.usa.gov/browse/LG-13064)
[Slack Thread](https://gsa-tts.slack.com/archives/C04RGFTFD70/p1713212455936609)

### Description of Changes:
* Use `t(string_html)` instead of `I18n.t(string_html)`, so that HTML is not escaped to text.
* Updated `span` classes from `text-heavy` to `text-bold`, which is already in our stylesheets and more legible.
* Updated tests to match appropriate text.
* Updated `caniuse-lite`.

### PR Checklist:

1. [x] Have you linted and tested your code locally prior to submission?
2. [x] Have you tagged the appropriate dev(s) for review?
3. [x] Have you linked to any relevant tickets or conversations?

### PR Review Standards: 
- Consider using [Conventional Comments](https://conventionalcomments.org/) to ensure that your feedback is clear and actionable.
- Ideally, PRs should be reviewed by at least 2 team members.
- All PRs must be approved before being merged. 
