### PR TITLE
Allow admins to edit integrations with empty help text

### DIFF
--- a/app/controllers/service_providers_controller.rb
+++ b/app/controllers/service_providers_controller.rb
@@ -46,12 +46,9 @@ class ServiceProvidersController < AuthenticatedController
 
   def new
     @service_provider = ServiceProvider.new
-    @help_text_empty = help_text_empty?
   end
 
-  def edit
-    @help_text_empty = help_text_empty?
-  end
+  def edit; end
 
   def show; end
 
@@ -76,13 +73,6 @@ class ServiceProvidersController < AuthenticatedController
 
 
   private
-
-  def help_text_empty?
-    service_provider.
-      help_text.
-      values.
-      all? {|text| text.values.all?('')}
-  end
 
   def service_provider
     @service_provider ||= ServiceProvider.find(params[:id])

--- a/app/controllers/service_providers_controller.rb
+++ b/app/controllers/service_providers_controller.rb
@@ -78,9 +78,10 @@ class ServiceProvidersController < AuthenticatedController
   private
 
   def help_text_empty?
-    service_provider.help_text['sign_in'].blank? &&
-      service_provider.help_text['sign_up'].blank? &&
-      service_provider.help_text['forgot_password'].blank?
+    service_provider.
+      help_text.
+      values.
+      all? {|text| text.values.all?('')}
   end
 
   def service_provider

--- a/app/helpers/service_provider_helper.rb
+++ b/app/helpers/service_provider_helper.rb
@@ -100,6 +100,14 @@ module ServiceProviderHelper
     !current_user.admin?
   end
 
+  def show_minimal_help_text_element?(help_text)
+    return false if current_user.admin?
+
+    help_text.
+      values.
+      all? {|text| text.values.all?(&:blank?)}
+  end
+
   private
 
   def config_hash(service_provider)

--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -347,7 +347,7 @@ B7xxt8BVc69rHV15A0qyx77CLSj3tCx2IUXVqRs5mlvA==
     <%= form.hint I18n.t('service_provider_form.active') %>
   </div>
 
-  <% if @help_text_empty && !current_user.admin? %>
+  <% if show_minimal_help_text_element?(service_provider.help_text) %>
     <p class="usa-label">Custom help text</p>
     <p>You have no existing help text.</p>
     <p>Do you need to add help text for your application? <a href="https://logingov.zendesk.com">Contact us</a>.</p>

--- a/app/views/service_providers/_form.html.erb
+++ b/app/views/service_providers/_form.html.erb
@@ -347,7 +347,7 @@ B7xxt8BVc69rHV15A0qyx77CLSj3tCx2IUXVqRs5mlvA==
     <%= form.hint I18n.t('service_provider_form.active') %>
   </div>
 
-  <% if @help_text_empty %>
+  <% if @help_text_empty && !current_user.admin? %>
     <p class="usa-label">Custom help text</p>
     <p>You have no existing help text.</p>
     <p>Do you need to add help text for your application? <a href="https://logingov.zendesk.com">Contact us</a>.</p>

--- a/spec/helpers/service_provider_helper_spec.rb
+++ b/spec/helpers/service_provider_helper_spec.rb
@@ -274,4 +274,85 @@ describe ServiceProviderHelper do
       end
     end
   end
+
+  describe '#show_minimal_help_text_element' do
+    include Devise::Test::ControllerHelpers
+    let(:user) { create(:user) }
+    before do
+      sign_in user
+    end
+
+    describe 'non admin user' do
+      describe 'when help text exists' do
+        describe 'and is not blank' do
+          let(:help_text) do
+            {
+              "sign_in"=> {"en"=>"<b>Some sign-in help text</b>"},
+              "sign_up"=> {"en"=>"<b>Some sign-up help text</b>"},
+              "forgot_password"=> {"en"=>"<b>Some forgot password help text</b>"}
+            }
+          end
+
+          it 'returns false' do
+            expect(
+              helper.show_minimal_help_text_element?(help_text)).to be false
+          end
+        end
+
+        describe 'it is just empty strings' do
+          let(:help_text) do
+            {
+              "sign_in"=> {"en"=>""},
+              "sign_up"=> {"en"=>""},
+              "forgot_password"=> {"en"=>""}
+            }
+          end
+
+          it 'returns true' do
+            expect(
+              helper.show_minimal_help_text_element?(help_text)).to be true
+          end
+        end
+
+
+        describe 'it is just empty strings with whitespace' do
+          let(:help_text) do
+            {
+              "sign_in"=> {"en"=>" "},
+              "sign_up"=> {"en"=>" "},
+              "forgot_password"=> {"en"=>"  "}
+            }
+          end
+
+          it 'returns true' do
+            expect(
+              helper.show_minimal_help_text_element?(help_text)).to be true
+          end
+        end
+
+        describe 'it is just some empty hashes' do
+          let(:help_text) do
+            {
+              "sign_in"=> {},
+              "sign_up"=> {},
+              "forgot_password"=> {}
+            }
+          end
+
+          it 'returns true' do
+            expect(
+              helper.show_minimal_help_text_element?(help_text)).to be true
+          end
+        end
+      end
+    end
+
+    describe 'an admin user' do
+      let(:user) { create(:admin) }
+      let(:help_text) { {} }
+      it 'returns false' do
+        expect(helper.show_minimal_help_text_element?(help_text)).to be false
+      end
+    end
+  end
 end

--- a/spec/helpers/service_provider_helper_spec.rb
+++ b/spec/helpers/service_provider_helper_spec.rb
@@ -287,9 +287,9 @@ describe ServiceProviderHelper do
         describe 'and is not blank' do
           let(:help_text) do
             {
-              "sign_in"=> {"en"=>"<b>Some sign-in help text</b>"},
-              "sign_up"=> {"en"=>"<b>Some sign-up help text</b>"},
-              "forgot_password"=> {"en"=>"<b>Some forgot password help text</b>"}
+              'sign_in'=> {'en'=>'<b>Some sign-in help text</b>'},
+              'sign_up'=> {'en'=>'<b>Some sign-up help text</b>'},
+              'forgot_password'=> {'en'=>'<b>Some forgot password help text</b>'},
             }
           end
 
@@ -302,9 +302,9 @@ describe ServiceProviderHelper do
         describe 'it is just empty strings' do
           let(:help_text) do
             {
-              "sign_in"=> {"en"=>""},
-              "sign_up"=> {"en"=>""},
-              "forgot_password"=> {"en"=>""}
+              'sign_in'=> {'en'=>''},
+              'sign_up'=> {'en'=>''},
+              'forgot_password'=> {'en'=>''},
             }
           end
 
@@ -318,9 +318,9 @@ describe ServiceProviderHelper do
         describe 'it is just empty strings with whitespace' do
           let(:help_text) do
             {
-              "sign_in"=> {"en"=>" "},
-              "sign_up"=> {"en"=>" "},
-              "forgot_password"=> {"en"=>"  "}
+              'sign_in'=> {'en'=>' '},
+              'sign_up'=> {'en'=>' '},
+              'forgot_password'=> {'en'=>'  '},
             }
           end
 
@@ -333,9 +333,9 @@ describe ServiceProviderHelper do
         describe 'it is just some empty hashes' do
           let(:help_text) do
             {
-              "sign_in"=> {},
-              "sign_up"=> {},
-              "forgot_password"=> {}
+              'sign_in'=> {},
+              'sign_up'=> {},
+              'forgot_password'=> {},
             }
           end
 


### PR DESCRIPTION
### Relevant Ticket or Conversation:
https://gsa-tts.slack.com/archives/C01SU3NB9T3/p1715365675325969

### Description of Changes:
* Adds a non-admin check to the initial conditional of the help_text editing check
* Updates the `help_text_empty?` method to handle when each help text key is an empty hash, and when it has translation values that are empty strings

### PR Checklist:

1. [ ] Have you linted and tested your code locally prior to submission?
2. [ ] Have you tagged the appropriate dev(s) for review?
3. [ ] Have you linked to any relevant tickets or conversations?

### PR Review Standards: 
- Consider using [Conventional Comments](https://conventionalcomments.org/) to ensure that your feedback is clear and actionable.
- Ideally, PRs should be reviewed by at least 2 team members.
- All PRs must be approved before being merged. 
